### PR TITLE
Fix for autocompletions breaking git symbols

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -152,7 +152,7 @@ spaceship_git_status() {
     echo -n "$(git_current_branch)"
     echo -n "%{$reset_color%}"
     echo -n "%{$fg_bold[red]%}"
-    echo -n "%{$indicators%}"
+    echo -n "$indicators"
     echo -n "%{$reset_color%}"
   fi
 }


### PR DESCRIPTION
On my setup auto completions break the git symbols part of the theme.
this commit fixes that.
example:
before i press tab:
![before tab](https://cloud.githubusercontent.com/assets/10766083/17771086/03941db8-654a-11e6-8543-b263e790aa0f.png)
after i press tab:
![after tab](https://cloud.githubusercontent.com/assets/10766083/17771104/17c23b58-654a-11e6-93b1-dc0674341423.png)


