### PR TITLE
Add vi-mode prompt info

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Currently it shows:
 * Current Node.js version, through NVM (`⬢`).
 * Current Ruby version, through RVM/RBENV/CHRUBY (`💎`).
 * Current Python virtualenv.
-* **Current Vi-mode (we need some help to finish this feature — [#16](https://github.com/denysdovhan/spaceship-zsh-theme/pull/16))**
+* Current Vi-mode mode.
 
 Want more features? Please, [open an issue](https://github.com/denysdovhan/spaceship-zsh-theme/issues/new) or send pull request.
 
@@ -142,6 +142,16 @@ Now you have ability to disable elements of Spaceship. All options must be overr
 | :------- | :-----: | ------- |
 | `SPACESHIP_VENV_SHOW` | `true` | Current Python virtualenv |
 
+### Vi-mode
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_VI_MODE_SHOW` | `true` | Current Vi-mode  |
+| `SPACESHIP_VI_MODE_INSERT` | `[I]` | Text to be shown when in insert mode |
+| `SPACESHIP_VI_MODE_NORMAL` | `[N]` | Text to be shown when in normal mode |
+
+Note: For oh-my-zsh users with vi-mode plugin enabled: Add `export RPS1="%{$reset_color%}"` before `source $ZSH/oh-my-zsh.sh` in ~/.zshrc to disable default `<<<` NORMAL mode indicator in right prompt.
+
 ### Example
 
 Here is all optins which may be changed. Copy this to your `~/.zshrc` to make it easy to change.
@@ -171,6 +181,11 @@ SPACESHIP_RUBY_SYMBOL='💎'
 
 # VENV
 SPACESHIP_VENV_SHOW=true
+
+# VI_MODE
+SPACESHIP_VI_MODE_SHOW=true
+SPACESHIP_VI_MODE_INSERT="[I]"
+SPACESHIP_VI_MODE_NORMAL="[N]"
 ```
 
 ## License

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -215,10 +215,17 @@ spaceship_ruby_version() {
   echo -n "%{$reset_color%}"
 }
 
+# Temporarily switch to vi-mode
+spaceship_enable_vi_mode() {
+  function zle-keymap-select() { zle reset-prompt; zle -R; };
+  zle -N zle-keymap-select;
+  bindkey -v;
+}
+
 # Show current vi_mode mode
 spaceship_vi_mode() {
   if [[ $(bindkey | grep "vi-quoted-insert") ]]; then # check if vi-mode enabled
-    echo -n "%{$fg_bold[gray]%}"
+    echo -n "%{$fg_bold[white]%}"
 
     MODE_INDICATOR="${SPACESHIP_VI_MODE_INSERT}"
 
@@ -276,4 +283,3 @@ export LS_COLORS='no=00:fi=00:di=01;34:ln=00;36:pi=40;33:so=01;35:do=01;35:bd=40
 # Zsh to use the same colors as ls
 # Link: http://superuser.com/a/707567
 zstyle ':completion:*' list-colors ${(s.:.)LS_COLORS}
-

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -34,6 +34,11 @@ SPACESHIP_RUBY_SYMBOL="${SPACESHIP_RUBY_SYMBOL:-💎}"
 # VENV
 SPACESHIP_VENV_SHOW="${SPACESHIP_VENV_SHOW:-true}"
 
+# VI_MODE
+SPACESHIP_VI_MODE_SHOW="${SPACESHIP_VI_MODE_SHOW:-true}"
+SPACESHIP_VI_MODE_INSERT="${SPACESHIP_VI_MODE_INSERT:-[I]}"
+SPACESHIP_VI_MODE_NORMAL="${SPACESHIP_VI_MODE_NORMAL:-[N]}"
+
 # Username.
 # If user is root, then pain it in red. Otherwise, just print in yellow.
 spaceship_user() {
@@ -210,6 +215,26 @@ spaceship_ruby_version() {
   echo -n "%{$reset_color%}"
 }
 
+# Show current vi_mode mode
+spaceship_vi_mode() {
+  if [[ $(bindkey | grep "vi-quoted-insert") ]]; then # check if vi-mode enabled
+    echo -n "%{$fg_bold[gray]%}"
+
+    MODE_INDICATOR="${SPACESHIP_VI_MODE_INSERT}"
+
+    case ${KEYMAP} in
+      main|viins)
+        MODE_INDICATOR="${SPACESHIP_VI_MODE_INSERT}"
+        ;;
+      vicmd)
+        MODE_INDICATOR="${SPACESHIP_VI_MODE_NORMAL}"
+        ;;
+    esac
+    echo -n "${MODE_INDICATOR}"
+    echo -n "%{$reset_color%} "
+  fi
+}
+
 # Command prompt.
 # Pain $PROMPT_SYMBOL in red if previous command was fail and
 # pain in green if all OK.
@@ -237,6 +262,7 @@ PROMPT=''
 [[ $SPACESHIP_PROMPT_ADD_NEWLINE == true ]] && PROMPT="$PROMPT$NEWLINE"
 PROMPT="$PROMPT"'$(spaceship_build_prompt) '
 [[ $SPACESHIP_PROMPT_SEPARATE_LINE == true ]] && PROMPT="$PROMPT$NEWLINE"
+[[ $SPACESHIP_VI_MODE_SHOW == true ]] && PROMPT="$PROMPT"'$(spaceship_vi_mode)'
 PROMPT="$PROMPT"'$(spaceship_return_status) '
 
 # Set PS2 - continuation interactive prompt
@@ -250,3 +276,4 @@ export LS_COLORS='no=00:fi=00:di=01;34:ln=00;36:pi=40;33:so=01;35:do=01;35:bd=40
 # Zsh to use the same colors as ls
 # Link: http://superuser.com/a/707567
 zstyle ':completion:*' list-colors ${(s.:.)LS_COLORS}
+


### PR DESCRIPTION
Hello, I think I found solutions to problems presented in comments in #16 issue.

1. To check if user is in vi-mode use: `bindkey | grep "vi-quoted-insert"` which will return nothing if in emacs mode.

2. To switch to vi-mode temporarily and not always see `[I]` use: `function zle-keymap-select() { zle reset-prompt; zle -R; }; zle -N zle-keymap-select; bindkey -v` which will tell zsh to update `KEYMAP` variable when mode changes (oh-my-zsh vi-mode plugin sets this).

I also cleared instructions for disabling built-in vi-mode oh-my-zsh plugin `<<<` right prompt. 

This is just tweaked version of #16, but I don't know how I can present these changes there, I can only comment.