### PR TITLE
fix bug in spaceship_vi_mode

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -224,7 +224,7 @@ spaceship_enable_vi_mode() {
 
 # Show current vi_mode mode
 spaceship_vi_mode() {
-  if $(bindkey | grep "vi-quoted-insert"); then # check if vi-mode enabled
+  if bindkey | grep "vi-quoted-insert" > /dev/null 2>&1; then # check if vi-mode enabled
     echo -n "%{$fg_bold[white]%}"
 
     MODE_INDICATOR="${SPACESHIP_VI_MODE_INSERT}"


### PR DESCRIPTION
L227 as is currently tries to execute the result of `bindkey | grep ...` which leads to zsh printing something along the lines of `zsh: command not found: "^Q"`.

This fixes that bug by not running the command in a subshell and piping the result of `grep` to `/dev/null`