### PR TITLE
Selective prepending for ruby version

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -306,8 +306,13 @@ spaceship_ruby_version() {
   # Do not show ruby prefix if prefixes are disabled
   [[ $SPACESHIP_PREFIX_SHOW == true ]] && echo -n "%B${SPACESHIP_PREFIX_RUBY}%b" || echo -n ' '
 
+  # Do not add v in ruby version if it doesn't start with a number
+  if [[ "${ruby_version}" =~ ^[0-9].+$ ]]; then
+    ruby_version="v${ruby_version}"
+  fi
+
   echo -n "%{$fg_bold[red]%}"
-  echo -n "${SPACESHIP_RUBY_SYMBOL}  v${ruby_version}"
+  echo -n "${SPACESHIP_RUBY_SYMBOL}  ${ruby_version}"
   echo -n "%{$reset_color%}"
 }
 


### PR DESCRIPTION
This PR adds a selective prepending of a `v` char to ruby versions.

Prepending a `v` is great when `ruby_version` is in the number only format like `2.4.0`, however `rvm` doesn't display MRI in that form but as `ruby-2.4.0`, and the version ends up displayed as `vruby-2.4.0`. 

The same happen to other ruby implementations like `jruby`.

This is how it looks before patching:

![image](https://cloud.githubusercontent.com/assets/1103597/22820498/c920bc6e-efc2-11e6-8b00-31330f333546.png)

![image](https://cloud.githubusercontent.com/assets/1103597/22820532/e5f54e72-efc2-11e6-8c6b-bd78551ff690.png)

This is after:

![image](https://cloud.githubusercontent.com/assets/1103597/22820553/f96e52f0-efc2-11e6-8caf-a34313f9b621.png)

