### PR TITLE
Fix wrong print order of DIR and HOST prefixes

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -115,18 +115,19 @@ spaceship_host() {
   if [[ -n $SSH_CONNECTION ]]; then
     echo -n "$(spaceship_user)"
 
-    # Do not show directory prefix if prefixes are disabled
-    [[ $SPACESHIP_PREFIX_SHOW == true ]] && echo -n "%B${SPACESHIP_PREFIX_DIR}%b" || echo -n ' '
-    # Display machine name
-    echo -n "%{$fg_bold[green]%}%m%{$reset_color%}"
     # Do not show host prefix if prefixes are disabled
     [[ $SPACESHIP_PREFIX_SHOW == true ]] && echo -n "%B${SPACESHIP_PREFIX_HOST}%b" || echo -n ' '
+    # Display machine name
+    echo -n "%{$fg_bold[green]%}%m%{$reset_color%}"
+
+    # Do not show directory prefix if prefixes are disabled
+    [[ $SPACESHIP_PREFIX_SHOW == true ]] && echo -n "%B${SPACESHIP_PREFIX_DIR}%b" || echo -n ' '
 
   elif [[ $LOGNAME != $USER ]] || [[ $USER == 'root' ]]; then
     echo -n "$(spaceship_user)"
 
-    # Do not show host prefix if prefixes are disabled
-    [[ $SPACESHIP_PREFIX_SHOW == true ]] && echo -n "%B${SPACESHIP_PREFIX_HOST}%b" || echo -n ' '
+    # Do not show directory prefix if prefixes are disabled
+    [[ $SPACESHIP_PREFIX_SHOW == true ]] && echo -n "%B${SPACESHIP_PREFIX_DIR}%b" || echo -n ' '
 
     echo -n "%{$reset_color%}"
   fi


### PR DESCRIPTION
I believe the print order of SPACESHIP_PREFIX_DIR and SPACESHIP_PREFIX_HOST is inverted.
This 
![screenshot_20170503_200328](https://cloud.githubusercontent.com/assets/1659633/25674610/bd5df27a-303b-11e7-8271-ece40b14be21.png)
becomes this
![screenshot_20170503_200342](https://cloud.githubusercontent.com/assets/1659633/25674618/c7647f1e-303b-11e7-8c56-1c2646869ab5.png)
after applying this patch.
