### PR TITLE
Faster deprecation check

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -244,7 +244,8 @@ _prompt_section() {
 _deprecated() {
   [[ -n $1 && -n $2 ]] || return
   local deprecated=$1 actual=$2 b=$bold_color r=$reset_color
-  [[ -n ${(P)deprecated} ]] || return
+  local deprecated_value=${(P)deprecated} # the value of variable name $deprecated
+  [[ -n $deprecated_value ]] || return
   echo "${b}\$$deprecated${r} is deprecated. Use ${b}\$$actual${r} instead."
 }
 

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -244,7 +244,7 @@ _prompt_section() {
 _deprecated() {
   [[ -n $1 && -n $2 ]] || return
   local deprecated=$1 actual=$2 b=$bold_color r=$reset_color
-  [[ -n $(eval echo \$$deprecated) ]] || return
+  [[ -n ${(P)deprecated} ]] || return
   echo "${b}\$$deprecated${r} is deprecated. Use ${b}\$$actual${r} instead."
 }
 


### PR DESCRIPTION
Use [ZSH parameter expansion](http://zshwiki.org/home/scripting/paramflags) to check if a variable has been set instead of eval. This removes almost completely the performance penalty for doing the deprecation checks.