### PR TITLE
Use rbenv version-name to read the current ruby version name

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -427,7 +427,7 @@ spaceship_ruby() {
   elif _exists chruby; then
     ruby_version=$(chruby | sed -n -e 's/ \* //p')
   elif _exists rbenv; then
-    ruby_version=$(rbenv version | sed -e 's/ (set.*$//')
+    ruby_version=$(rbenv version-name)
   else
     return
   fi


### PR DESCRIPTION
Version-name command returns the version without any noise. Using sed to clean up the output is not needed.