### PR TITLE
Fix the installer

### DIFF
--- a/install.zsh
+++ b/install.zsh
@@ -54,10 +54,10 @@ if [ ! -f "$SPACESHIP" ]; then
 
   if exists curl; then
     log "Downloading using curl:"
-    curl "$URL" -o "$SPACESHIP" || error "Filed to load using curl!" ; exit 1
+    curl "$URL" -o "$SPACESHIP" || $(error "Failed to load using curl!" && exit 1)
   elif exists wget; then
     log "Downloading using wget:"
-    wget "$URL" -O "$SPACESHIP" || error "Filed to load using wget!" ; exit 1
+    wget "$URL" -O "$SPACESHIP" || $(error "Failed to load using wget!" && exit 1)
   else
     # Exit with error
     error "curl and wget are unavailable!"
@@ -74,9 +74,9 @@ if [[ -z $ZSH_CUSTOM ]]; then
 fi
 
 # Linking
-log "Linking $SPACESHIP to $DIST..."
+log "Moving $SPACESHIP to $DIST..."
 mkdir -p "$(dirname $DIST)"
-ln -sf "$SPACESHIP" "$DIST"
+mv -f "$SPACESHIP" "$DIST"
 
 # Add source command to ~/.zshrc
 log "Sourcing Spacehsip in ~/.zshrc..."
@@ -85,6 +85,6 @@ echo 'source "'"$DIST"'"'           >> "$HOME/.zshrc"
 
 # Replace current theme to Spaceship
 log 'Attempting to change $ZSH_THEME to "spaceship"...'
-sed -i '' 's/ZSH_THEME=.*$/ZSH_THEME="spaceship"/g' "$HOME/.zshrc" \
+sed -i'' 's/ZSH_THEME=.*$/ZSH_THEME="spaceship"/g' "$HOME/.zshrc" \
   && success "Done! Please, reload your terminal." \
   || error "Cannot change theme in ~/.zshrc. Please, do it by yourself." \

--- a/install.zsh
+++ b/install.zsh
@@ -76,7 +76,7 @@ fi
 # Linking
 log "Moving $SPACESHIP to $DIST..."
 mkdir -p "$(dirname $DIST)"
-mv -f "$SPACESHIP" "$DIST"
+cp -f "$SPACESHIP" "$DIST"
 
 # Add source command to ~/.zshrc
 log "Sourcing Spacehsip in ~/.zshrc..."

--- a/install.zsh
+++ b/install.zsh
@@ -74,7 +74,7 @@ if [[ -z $ZSH_CUSTOM ]]; then
 fi
 
 # Linking
-log "Moving $SPACESHIP to $DIST..."
+log "Copying $SPACESHIP to $DIST..."
 mkdir -p "$(dirname $DIST)"
 cp -f "$SPACESHIP" "$DIST"
 


### PR DESCRIPTION
The `installer.zsh` script failed on my macOS work laptop earlier today, and failed again the same way on my Arch Linux machine tonight.

I'm fairly certain this is due to the formatting of the `curl` and `wget` lines, since the installer bailed without an error message, I assumed it had jumped from the successful `curl` command over to the `exit 1` at the end of the line.

This fix ensures that the `exit 1` is in the same case as the error message for the `curl` and `wget` commands.

Additionally, I have changed the symlink function to be a copy function. The reason for this is that when `curl` or `wget` download the file into the /tmp folder, it will be removed on the next reboot. Creating a symlink from the /tmp folder is a bad idea.

Finally, I changed `sed -i ''` to `sed -i''` in order to satisfy Linux's sed argument expectations.