### PR TITLE
Add spaces in _displaytime

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -303,9 +303,9 @@ _displaytime() {
   local H=$((T/60/60%24))
   local M=$((T/60%60))
   local S=$((T%60))
-  [[ $D > 0 ]] && printf '%dd' $D
-  [[ $H > 0 ]] && printf '%dh' $H
-  [[ $M > 0 ]] && printf '%dm' $M
+  [[ $D > 0 ]] && printf '%dd ' $D
+  [[ $H > 0 ]] && printf '%dh ' $H
+  [[ $M > 0 ]] && printf '%dm ' $M
   printf '%ds' $S
 }
 


### PR DESCRIPTION
For better readability.

Before: `1d8h54m13s`.
After: `1d 8h 54m 13s`