### PR TITLE
Show required zsh version in badge and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,7 +720,7 @@ MIT © [Denys Dovhan](http://denysdovhan.com)
 [npm-image]: https://img.shields.io/npm/v/spaceship-zsh-theme.svg?style=flat-square
 
 [zsh-url]: http://zsh.org/
-[zsh-image]: https://img.shields.io/badge/zsh-v5.0.5-777777.svg?style=flat-square
+[zsh-image]: https://img.shields.io/badge/zsh->=v5.0.5-777777.svg?style=flat-square
 
 [omz-url]: http://ohmyz.sh/
 [omz-image]: https://img.shields.io/badge/dependency-oh--my--zsh-c5d928.svg?style=flat-square

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can find more examples with different color schemes in [Screenshots](https:/
 
 For correct work you will first need:
 
-* A [`zsh`](http://www.zsh.org/) must be installed
+* A [`zsh`](http://www.zsh.org/) (v5.0.5 or recent) must be installed
 * A zsh–framework like [oh-my-zsh], [antigen] or [zgen]
 
 ## Installing
@@ -720,7 +720,7 @@ MIT © [Denys Dovhan](http://denysdovhan.com)
 [npm-image]: https://img.shields.io/npm/v/spaceship-zsh-theme.svg?style=flat-square
 
 [zsh-url]: http://zsh.org/
-[zsh-image]: https://img.shields.io/badge/shell-zsh-777777.svg?style=flat-square
+[zsh-image]: https://img.shields.io/badge/zsh-v5.0.5-777777.svg?style=flat-square
 
 [omz-url]: http://ohmyz.sh/
 [omz-image]: https://img.shields.io/badge/dependency-oh--my--zsh-c5d928.svg?style=flat-square


### PR DESCRIPTION
Fixes #93 

In #93 as [mentioned][1] by @simonvizzini the original issue was caused by incompatible `ZSH` version. `spaceship-zsh-theme` requires `ZSH >= 5.0.3`. 

`ZSH` included prompt sequence formatting with `%F` and `%K` in 5.0.3 with https://github.com/zsh-users/zsh/commit/8a9b141652a0e4157056dc21e36a64ac712a7ee7  which is used by `spaceship-zsh-theme`. 

But releases [5.0.3 and 5.0.4 were replaced with 5.0.5][2] due to serious bugs. So, minimum required version is now included in `READE.md` as `5.0.5`.

[1]: https://github.com/denysdovhan/spaceship-zsh-theme/issues/93#issuecomment-301806636
[2]: http://zsh.sourceforge.net/releases.html

#### zsh 5.0.2
![](https://i.imgur.com/4w3tN5k.png)

#### zsh 5.0.3
![](https://i.imgur.com/Gk7IAEK.png)