### PR TITLE
Add dotnet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Currently it shows:
 * Current Docker version and connected machine (`🐳`).
 * Current Python virtualenv.
 * Current Python pyenv (`🐍`).
+* Current .NET SDK version, through dotnet-cli (`.NET`).
 * Current Vi-mode mode ([with handy aliases for temporarily enabling](#vi-mode)).
 * Optional time stamps 12/24hr in format ([how to enable](#time)).
 * Execution time of the last command if it exceeds the set threshold.
@@ -168,6 +169,7 @@ SPACESHIP_PROMPT_ORDER=(
   docker        # Docker section
   venv          # virtualenv section
   pyenv         # Pyenv section
+  dotnet        # .NET section
   exec_time     # Execution time
   line_sep      # Line break
   vi_mode       # Vi-mode indicator
@@ -457,6 +459,18 @@ Go section is shown only in directories that contain `requirements.txt` or any o
 | `SPACESHIP_PYENV_SYMBOL` | `🐍 ` | Character to be shown before Pyenv version |
 | `SPACESHIP_PYENV_COLOR` | `yellow` | Color of Pyenv section |
 
+### .NET (`dotnet`)
+
+.NET section is shown only in directories that contains a `project.json` or `global.json` file, or a file with one of these extensions: `.csproj`, `.xproj` or `.sln`.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_DOTNET_SHOW` | `true` | Current .NET section |
+| `SPACESHIP_DOTNET_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before .NET section |
+| `SPACESHIP_DOTNET_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after .NET section |
+| `SPACESHIP_DOTNET_SYMBOL` | `.NET ` | Character to be shown before .NET version |
+| `SPACESHIP_DOTNET_COLOR` | `128` | [Color code](https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg) of .NET section |
+
 ### Execution time (`exec_time`)
 
 Execution time of the last command. Will be displayed if it exceeds the set threshold of time.
@@ -692,6 +706,13 @@ SPACESHIP_PYENV_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"
 SPACESHIP_PYENV_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
 SPACESHIP_PYENV_SYMBOL="🐍 "
 SPACESHIP_PYENV_COLOR="yellow"
+
+# DOTNET
+SPACESHIP_DOTNET_SHOW=true
+SPACESHIP_DOTNET_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"
+SPACESHIP_DOTNET_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_DOTNET_SYMBOL=".NET "
+SPACESHIP_DOTNET_COLOR="128"
 
 # VI_MODE
 SPACESHIP_VI_MODE_SHOW=true

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -34,6 +34,7 @@ if [ ! -n "$SPACESHIP_PROMPT_ORDER" ]; then
     docker
     venv
     pyenv
+    dotnet
     exec_time
     line_sep
     vi_mode
@@ -209,6 +210,13 @@ SPACESHIP_PYENV_PREFIX="${SPACESHIP_PYENV_PREFIX:="$SPACESHIP_PROMPT_DEFAULT_PRE
 SPACESHIP_PYENV_SUFFIX="${SPACESHIP_PYENV_SUFFIX:="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_PYENV_SYMBOL="${SPACESHIP_PYENV_SYMBOL:="🐍 "}"
 SPACESHIP_PYENV_COLOR="${SPACESHIP_PYENV_COLOR:="yellow"}"
+
+# DOTNET
+SPACESHIP_DOTNET_SHOW="${SPACESHIP_DOTNET_SHOW:=true}"
+SPACESHIP_DOTNET_PREFIX="${SPACESHIP_DOTNET_PREFIX:="$SPACESHIP_PROMPT_DEFAULT_PREFIX"}"
+SPACESHIP_DOTNET_SUFFIX="${SPACESHIP_DOTNET_SUFFIX:="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_DOTNET_SYMBOL="${SPACESHIP_DOTNET_SYMBOL:=".NET "}"
+SPACESHIP_DOTNET_COLOR="${SPACESHIP_DOTNET_COLOR:="128"}"
 
 # VI_MODE
 SPACESHIP_VI_MODE_SHOW="${SPACESHIP_VI_MODE_SHOW:=true}"
@@ -807,6 +815,31 @@ spaceship_pyenv() {
     "$SPACESHIP_PYENV_PREFIX" \
     "${SPACESHIP_PYENV_SYMBOL}${pyenv_status}" \
     "$SPACESHIP_PYENV_SUFFIX"
+}
+
+# DOTNET
+# Show current version of .NET SDK
+spaceship_dotnet() {
+  [[ $SPACESHIP_DOTNET_SHOW == false ]] && return
+
+  # Show DOTNET status only for folders containing project.json, global.json, .csproj, .xproj or .sln files
+  [[ -f project.json || -f global.json || -n *.csproj(#qN) || -n *.xproj(#qN) || -n *.sln(#qN) ]] || return
+
+  local dotnet_version
+
+  if _exists dotnet; then
+    # dotnet-cli automatically handles SDK pinning (specified in a global.json file)
+    # therefore, this already returns the expected version for the current directory
+    dotnet_version=$(dotnet --version 2>/dev/null)
+  else
+    return
+  fi
+
+  _prompt_section \
+    "$SPACESHIP_DOTNET_COLOR" \
+    "$SPACESHIP_DOTNET_PREFIX" \
+    "${SPACESHIP_DOTNET_SYMBOL}${dotnet_version}" \
+    "$SPACESHIP_DOTNET_SUFFIX"
 }
 
 # EXECUTION TIME


### PR DESCRIPTION
Hi! I've added support to detect the presence of a .NET project and show the .NET SDK version, using the dotnet CLI.

Detection is made for the following file/file types:
* `project.json` / `.xproj` (support for older .NET Core projects tooling)
* `.csproj` (current MSBUILD-based tooling)
* `global.json` (for [SDK pinning](https://www.hanselman.com/blog/ManagingDotnetCore20AndDotnetCore1xVersionedSDKsOnTheSameMachine.aspx) in a directory/project)
* `.sln` (Visual Studio's solution file)

Some things that depart from the 'standard' way of how things have been done for other sections:
* I didn't found a suitable character for representing dotnet, and ended using the string `.NET` instead. Suggestions are welcome!
* I think the most representative color for this section was one like the used on the [.NET Foundation](https://dotnetfoundation.org/) site. That's why I've put a color code (`128`) instead of a color name, and also because the most similar to that one would be `magenta`, which is already the default color for the `Git` section, but I wanted to avoid repetition. I'm not sure if this pose a compatibility issue in some terminals (tested on GNOME Terminal).

I'm also wondering if the test expression to detect the files can be simplified a bit.

Some pics:

![sample-1](https://user-images.githubusercontent.com/6424021/27011889-6ec2677a-4e9c-11e7-92f0-41954d175472.png)

Note that for preview versions of the SDK, the version returned is actually a long one, but I think it's correct to show the full string:

![sample-2](https://user-images.githubusercontent.com/6424021/27011891-77106e2c-4e9c-11e7-873a-70344dead9d9.png)

