### PR TITLE
Drop Oh-My-Zsh dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ You can find more examples with different color schemes in [Screenshots](https:/
 For correct work you will first need:
 
 * A [`zsh`](http://www.zsh.org/) (v5.0.5 or recent) must be installed
-* A zsh–framework like [oh-my-zsh], [antigen] or [zgen]
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@
 
 [![NPM version][npm-image]][npm-url]
 [![ZSH][zsh-image]][zsh-url]
+![Dependency][dependency-image]
 [![Donatation][donate-image]][donate-url]
 
-> An [“ZSH!”][zsh-url] theme for Astronauts.
+> An [ZSH][zsh-url] prompt for Astronauts.
 
-Spaceship is a minimalistic, powerful and extremely customizable [“ZSH!”][zsh-url] theme. It combines everything you may need for convenient work, without unnecessary complications, like a real spaceship.
+Spaceship is a minimalistic, powerful and extremely customizable [ZSH][zsh-url] prompt. It combines everything you may need for convenient work, without unnecessary complications, like a real spaceship.
 
 Currently it shows:
 
@@ -720,6 +721,8 @@ MIT © [Denys Dovhan](http://denysdovhan.com)
 
 [zsh-url]: http://zsh.org/
 [zsh-image]: https://img.shields.io/badge/zsh->=v5.0.5-777777.svg?style=flat-square
+
+[dependency-image]:  https://img.shields.io/badge/dependencies-none-c5d928.svg?style=flat-square
 
 [donate-url]: https://www.liqpay.com/en/checkout/380951100392
 [donate-image]: https://img.shields.io/badge/support-donate-yellow.svg?style=flat-square

--- a/README.md
+++ b/README.md
@@ -79,23 +79,14 @@ For correct work you will first need:
 npm install -g spaceship-zsh-theme
 ```
 
-Done. This command should link `spaceship.zsh-theme` to your `$ZSH_CUSTOM/themes` and set `$ZSH_CUSTOM` to `"spaceship"`. Just reload your terminal.
+Done. This command should link `spaceship.zsh` as `prompt_spaceship_setup` to your `$fpath` and set `prompt spaceship` in `.zshrc`. Just reload your terminal.
 
 **Tip:** Update Spaceship to new versions as any other package.
 
 ### [oh-my-zsh]
 
-Installing using **curl**:
-
-```zsh
-curl -o - https://raw.githubusercontent.com/denysdovhan/spaceship-zsh-theme/master/install.zsh | zsh
-```
-
-Installing using **wget**:
-
-```zsh
-wget -O - https://raw.githubusercontent.com/denysdovhan/spaceship-zsh-theme/master/install.zsh | zsh
-```
+- Set `ZSH_THEME=""` in your `.zshrc`
+- Follow instructions in [manual](https://github.com/denysdovhan/spaceship-zsh-theme#manual) installation.
 
 ### [antigen]
 
@@ -133,10 +124,31 @@ zplug denysdovhan/spaceship-zsh-theme, use:spaceship.zsh, from:github, as:theme
 
 If you have problems with approches above, follow these instructions:
 
-1. Download the theme [here](https://raw.githubusercontent.com/denysdovhan/spaceship-zsh-theme/master/spaceship.zsh)
-2. Rename `spaceship.zsh` to `spaceship.zsh-theme`
-3. Put the file `spaceship.zsh-theme` in `$ZSH_CUSTOM/themes/`
-4. Add the line to your `~/.zshrc`: `ZSH_THEME="spaceship"`
+- Download the theme [here](https://raw.githubusercontent.com/denysdovhan/spaceship-zsh-theme/master/spaceship.zsh)
+- Symlink `spaceship.zsh` to somewhere in `$fpath` as `prompt_spaceship_setup`.
+
+Run `echo $fpath` to see possible locations. Like,
+```console
+$ ln -sf "$PWD/spaceship.zsh" "/usr/local/share/zsh/site-functions/prompt_spaceship_setup"
+```
+
+For a user-specific installation (which would not require escalated privileges), simply add a directory to `$fpath` for that user:
+```sh
+# .zshrc
+fpath=( "$HOME/.zfunctions" $fpath )
+```
+Then install the theme there:
+```console
+$ ln -sf "$PWD/spaceship.zsh" "$HOME/.zfunctions/prompt_spaceship_setup"
+```
+
+- Initialize prompt system and choose `spaceship`
+
+```sh
+# .zshrc
+autoload -U promptinit; promptinit
+prompt spaceship
+```
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,11 @@
 
 [![NPM version][npm-image]][npm-url]
 [![ZSH][zsh-image]][zsh-url]
-[![Oh-My-Zsh][omz-image]][omz-url]
 [![Donatation][donate-image]][donate-url]
 
-> An [“Oh My ZSH!”][oh-my-zsh] theme for Astronauts.
+> An [“ZSH!”][zsh-url] theme for Astronauts.
 
-Spaceship is a minimalistic, powerful and extremely customizable [“Oh My ZSH!”][oh-my-zsh] theme. It combines everything you may need for convenient work, without unnecessary complications, like a real spaceship.
+Spaceship is a minimalistic, powerful and extremely customizable [“ZSH!”][zsh-url] theme. It combines everything you may need for convenient work, without unnecessary complications, like a real spaceship.
 
 Currently it shows:
 
@@ -99,7 +98,7 @@ wget -O - https://raw.githubusercontent.com/denysdovhan/spaceship-zsh-theme/mast
 
 ### [antigen]
 
-Add the following snippet `~/.zshrc` after the line `antigen use oh-my-zsh`:
+Add the following snippet in your `~/.zshrc``:
 
 ```
 antigen theme https://github.com/denysdovhan/spaceship-zsh-theme spaceship
@@ -721,9 +720,6 @@ MIT © [Denys Dovhan](http://denysdovhan.com)
 
 [zsh-url]: http://zsh.org/
 [zsh-image]: https://img.shields.io/badge/zsh->=v5.0.5-777777.svg?style=flat-square
-
-[omz-url]: http://ohmyz.sh/
-[omz-image]: https://img.shields.io/badge/dependency-oh--my--zsh-c5d928.svg?style=flat-square
 
 [donate-url]: https://www.liqpay.com/en/checkout/380951100392
 [donate-image]: https://img.shields.io/badge/support-donate-yellow.svg?style=flat-square

--- a/install.zsh
+++ b/install.zsh
@@ -67,10 +67,14 @@ else
   log "Spaceship is present in current directory"
 fi
 
-# Check if $ZSH_CUSTOM is available
-if [[ -z $ZSH_CUSTOM ]]; then
-  error '$ZSH_CUSTOM is not defined!'
-  exit 1
+# Choose Installation path
+
+DIST="/usr/local/share/zsh/site-functions"
+if [[ ! -w "$DIST" ]]; then
+  log "Failed to symlink $SPACESHIP to $DIST, Using $HOME/.zfunctions"
+  DIST="$HOME/.zfunctions"
+  log  "Adding $DIST to fpath"
+  echo 'fpath=( "'"$DIST"'" $fpath )' >> "$HOME/.zshrc"
 fi
 
 # Linking

--- a/install.zsh
+++ b/install.zsh
@@ -3,7 +3,7 @@
 # Author: Denys Dovhan, denysdovhan.com
 # https://github.com/denysdovhan/spaceship-zsh-theme
 
-# Source ~/.zshrc because we need oh-my-zsh variables
+# Source ~/.zshrc
 source "$HOME/.zshrc"
 
 # ------------------------------------------------------------------------------
@@ -28,8 +28,8 @@ paint() {
 # Logging functions.
 # USAGE:
 #   log|error|success [text...]
-log()     {        paint 'cyan'  "SPACESHIP: $*"        }
-error()   { echo ; paint 'red'   "SPACESHIP: $*" ; echo }
+log()     { echo ; paint 'cyan'  "SPACESHIP: $*" }
+error()   { echo ; paint 'red'   "SPACESHIP: $*" }
 success() { echo ; paint 'green' "SPACESHIP: $*" ; echo }
 
 # ------------------------------------------------------------------------------
@@ -39,7 +39,6 @@ success() { echo ; paint 'green' "SPACESHIP: $*" ; echo }
 
 URL='https://raw.githubusercontent.com/denysdovhan/spaceship-zsh-theme/master/spaceship.zsh'
 SPACESHIP="$PWD/spaceship.zsh"
-DIST="$ZSH_CUSTOM/themes/spaceship.zsh-theme"
 
 # ------------------------------------------------------------------------------
 # MAIN
@@ -77,18 +76,24 @@ if [[ ! -w "$DIST" ]]; then
   echo 'fpath=( "'"$DIST"'" $fpath )' >> "$HOME/.zshrc"
 fi
 
-# Linking
-log "Linking $SPACESHIP to $DIST..."
+# Link prompt to fpath
+log "Linking $SPACESHIP to $DIST/prompt_spaceship_setup..."
 mkdir -p "$(dirname $DIST)"
-ln -sf "$SPACESHIP" "$DIST"
+ln -sf "$SPACESHIP" "$DIST/prompt_spaceship_setup"
 
-# Add source command to ~/.zshrc
-log "Sourcing Spacehsip in ~/.zshrc..."
-echo '\n'                           >> "$HOME/.zshrc"
-echo 'source "'"$DIST"'"'           >> "$HOME/.zshrc"
+local msg="
+  autoload -U promptinit; promptinit
+  prompt spaceship
+  "
 
-# Replace current theme to Spaceship
-log 'Attempting to change $ZSH_THEME to "spaceship"...'
-sed -i '' 's/ZSH_THEME=.*$/ZSH_THEME="spaceship"/g' "$HOME/.zshrc" \
-  && success "Done! Please, reload your terminal." \
-  || error "Cannot change theme in ~/.zshrc. Please, do it by yourself." \
+read -q "choice?Do you want to set prompt now (Y/n) ?
+This will append the following to your .zshrc $msg"
+
+if [[ $choice == "y" ]]; then
+  echo 'autoload -U promptinit; promptinit' >> "$HOME/.zshrc"
+  echo 'prompt spaceship'                   >> "$HOME/.zshrc"
+  success "Done! Please, reload your terminal."
+else
+  error "Please manually update your .zshrc with the following"
+  echo "$msg"
+fi

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "shell",
     "zsh",
     "zsh-theme",
-    "oh-my-zsh",
     "terminal"
   ],
   "author": "Denys Dovhan <email@denysdovhan.com> (http://denysdovhan.com/)",

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -411,9 +411,8 @@ spaceship_git_branch() {
 
   _is_git || return
 
-  if [[ $ret != 0 ]]; then
-    [[ $ret == 128 ]] && return
   local ref=$(command git symbolic-ref --quiet HEAD 2> /dev/null) ret=$?
+  if [[ $ret != 0 && $ret != 128 ]]; then
     ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
   fi
 

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -411,11 +411,9 @@ spaceship_git_branch() {
 
   _is_git || return
 
-  local ref
-  ref=$(command git symbolic-ref --quiet HEAD 2> /dev/null)
-  local ret=$?
   if [[ $ret != 0 ]]; then
     [[ $ret == 128 ]] && return
+  local ref=$(command git symbolic-ref --quiet HEAD 2> /dev/null) ret=$?
     ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
   fi
 
@@ -433,9 +431,9 @@ spaceship_git_status() {
 
   _is_git || return
 
-  local INDEX STATUS
+  local INDEX git_status=""
+
   INDEX=$(command git status --porcelain -b 2> /dev/null)
-  git_status=""
 
   if $(echo "$INDEX" | command grep -E '^\?\? ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_UNTRACKED$git_status"

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -411,6 +411,16 @@ spaceship_git_branch() {
 
   _is_git || return
 
+  local ref
+  ref=$(command git symbolic-ref --quiet HEAD 2> /dev/null)
+  local ret=$?
+  if [[ $ret != 0 ]]; then
+    [[ $ret == 128 ]] && return
+    ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
+  fi
+
+  local git_current_branch=${ref#refs/heads/}
+
   _prompt_section \
     "$SPACESHIP_GIT_BRANCH_COLOR" \
     "$SPACESHIP_GIT_BRANCH_PREFIX$(git_current_branch)$SPACESHIP_GIT_BRANCH_SUFFIX"

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -412,7 +412,7 @@ spaceship_git_branch() {
   _is_git || return
 
   local ref=$(command git symbolic-ref --quiet HEAD 2> /dev/null) ret=$?
-  if [[ $ret != 0 && $ret != 128 ]]; then
+  if [[ $ret != 0 ]]; then
     ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
   fi
 

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -999,7 +999,7 @@ spaceship_ps2() {
 
 # Setup required environment variables
 # All preparation before drawing prompt should be done here
-spaceship_setup() {
+prompt_spaceship_setup() {
   autoload -Uz add-zsh-hook
   # Add exec_time hooks
   add-zsh-hook preexec spaceship_exec_time_preexec_hook
@@ -1023,4 +1023,4 @@ spaceship_setup() {
 
 # Entry point
 # Pass all arguments to the spaceship_setup function
-spaceship_setup "$@"
+prompt_spaceship_setup "$@"

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -405,7 +405,7 @@ spaceship_dir() {
 }
 
 # GIT BRANCH
-# Show current git brunch using git_current_status from Oh-My-Zsh
+# Show current git branch
 spaceship_git_branch() {
   [[ $SPACEHIP_GIT_BRANCH_SHOW == false ]] && return
 
@@ -417,27 +417,67 @@ spaceship_git_branch() {
 }
 
 # GIT STATUS
-# Check if current dir is a git repo, set up ZSH_THEME_* variables
-# and show git status using git_prompt_status from Oh-My-Zsh
-# Reference:
-#   https://github.com/robbyrussell/oh-my-zsh/blob/master/lib/git.zsh
+# Show git status
 spaceship_git_status() {
   [[ $SPACESHIP_GIT_STATUS_SHOW == false ]] && return
 
   _is_git || return
 
-  ZSH_THEME_GIT_PROMPT_UNTRACKED=$SPACESHIP_GIT_STATUS_UNTRACKED
-  ZSH_THEME_GIT_PROMPT_ADDED=$SPACESHIP_GIT_STATUS_ADDED
-  ZSH_THEME_GIT_PROMPT_MODIFIED=$SPACESHIP_GIT_STATUS_MODIFIED
-  ZSH_THEME_GIT_PROMPT_RENAMED=$SPACESHIP_GIT_STATUS_RENAMED
-  ZSH_THEME_GIT_PROMPT_DELETED=$SPACESHIP_GIT_STATUS_DELETED
-  ZSH_THEME_GIT_PROMPT_STASHED=$SPACESHIP_GIT_STATUS_STASHED
-  ZSH_THEME_GIT_PROMPT_UNMERGED=$SPACESHIP_GIT_STATUS_UNMERGED
-  ZSH_THEME_GIT_PROMPT_AHEAD=$SPACESHIP_GIT_STATUS_AHEAD
-  ZSH_THEME_GIT_PROMPT_BEHIND=$SPACESHIP_GIT_STATUS_BEHIND
-  ZSH_THEME_GIT_PROMPT_DIVERGED=$SPACESHIP_GIT_STATUS_DIVERGED
+  local INDEX STATUS
+  INDEX=$(command git status --porcelain -b 2> /dev/null)
+  git_status=""
 
-  local git_status="$(git_prompt_status)"
+  if $(echo "$INDEX" | command grep -E '^\?\? ' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_UNTRACKED$git_status"
+  fi
+
+  if $(echo "$INDEX" | command grep '^A[ MDAU] ' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_ADDED$git_status"
+  elif $(echo "$INDEX" | command grep '^UA' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_ADDED$git_status"
+  fi
+
+  if $(echo "$INDEX" | command grep '^M[ MD] ' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_MODIFIED$git_status"
+  elif $(echo "$INDEX" | command grep '^[ MARC]M ' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_MODIFIED$git_status"
+  fi
+
+  if $(echo "$INDEX" | command grep '^R[ MD] ' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_RENAMED$git_status"
+  fi
+
+  if $(echo "$INDEX" | command grep '^[MARCDU] D ' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_DELETED$git_status"
+  elif $(echo "$INDEX" | command grep '^D[ UM] ' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_DELETED$git_status"
+  fi
+
+  if $(command git rev-parse --verify refs/stash >/dev/null 2>&1); then
+    git_status="$SPACESHIP_GIT_STATUS_STASHED$git_status"
+  fi
+
+  if $(echo "$INDEX" | command grep '^U[UDA] ' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_UNMERGED$git_status"
+  elif $(echo "$INDEX" | command grep '^AA ' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_UNMERGED$git_status"
+  elif $(echo "$INDEX" | command grep '^DD ' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_UNMERGED$git_status"
+  elif $(echo "$INDEX" | command grep '^[DA]U ' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_UNMERGED$git_status"
+  fi
+
+  if $(echo "$INDEX" | command grep '^## [^ ]\+ .*ahead' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_AHEAD$git_status"
+  fi
+
+  if $(echo "$INDEX" | command grep '^## [^ ]\+ .*behind' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_BEHIND$git_status"
+  fi
+
+  if $(echo "$INDEX" | command grep '^## [^ ]\+ .*diverged' &> /dev/null); then
+    git_status="$SPACESHIP_GIT_STATUS_DIVERGED$git_status"
+  fi
 
   if [[ -n $git_status ]]; then
     # Status prefixes are colorized

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -425,6 +425,10 @@ spaceship_git_branch() {
 
 # GIT STATUS
 # Show git status
+#   We used to depend on OMZ git library,
+#   But it doesn't handle many of the status indicator combinations.
+#   Also, It's hard to maintain external dependency. See PR #147 at https://git.io/vQkkB
+#   See git help status to know more about status formats
 spaceship_git_status() {
   [[ $SPACESHIP_GIT_STATUS_SHOW == false ]] && return
 
@@ -434,36 +438,43 @@ spaceship_git_status() {
 
   INDEX=$(command git status --porcelain -b 2> /dev/null)
 
+  # Check for untracked files
   if $(echo "$INDEX" | command grep -E '^\?\? ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_UNTRACKED$git_status"
   fi
 
+  # Check for staged files
   if $(echo "$INDEX" | command grep '^A[ MDAU] ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_ADDED$git_status"
   elif $(echo "$INDEX" | command grep '^UA' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_ADDED$git_status"
   fi
 
+  # Check for modified files
   if $(echo "$INDEX" | command grep '^M[ MD] ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_MODIFIED$git_status"
   elif $(echo "$INDEX" | command grep '^[ MARC]M ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_MODIFIED$git_status"
   fi
 
+  # Check for renamed files
   if $(echo "$INDEX" | command grep '^R[ MD] ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_RENAMED$git_status"
   fi
 
+  # Check for deleted files
   if $(echo "$INDEX" | command grep '^[MARCDU] D ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_DELETED$git_status"
   elif $(echo "$INDEX" | command grep '^D[ UM] ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_DELETED$git_status"
   fi
 
+  # Check for stashes
   if $(command git rev-parse --verify refs/stash >/dev/null 2>&1); then
     git_status="$SPACESHIP_GIT_STATUS_STASHED$git_status"
   fi
 
+  # Check for unmerged files
   if $(echo "$INDEX" | command grep '^U[UDA] ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_UNMERGED$git_status"
   elif $(echo "$INDEX" | command grep '^AA ' &> /dev/null); then
@@ -474,14 +485,17 @@ spaceship_git_status() {
     git_status="$SPACESHIP_GIT_STATUS_UNMERGED$git_status"
   fi
 
+  # Check whether branch is ahead
   if $(echo "$INDEX" | command grep '^## [^ ]\+ .*ahead' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_AHEAD$git_status"
   fi
 
+  # Check whether branch is behind
   if $(echo "$INDEX" | command grep '^## [^ ]\+ .*behind' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_BEHIND$git_status"
   fi
 
+  # Check wheather branch has diverged
   if $(echo "$INDEX" | command grep '^## [^ ]\+ .*diverged' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_DIVERGED$git_status"
   fi

--- a/uninstall.zsh
+++ b/uninstall.zsh
@@ -9,7 +9,7 @@
 # ------------------------------------------------------------------------------
 
 ZSHRC="$HOME/.zshrc"
-DIST="$ZSH_CUSTOM/themes/spaceship.zsh-theme"
+DIST="/usr/local/share/zsh/site-functions/prompt_spaceship_setup"
 
 # ------------------------------------------------------------------------------
 # HELPERS
@@ -36,37 +36,31 @@ success() { echo ; paint 'green'  "SPACESHIP: $*" ; echo }
 # Checkings and uninstalling process
 # ------------------------------------------------------------------------------
 
-# Source ~/.zshrc because we need oh-my-zsh variables
+# Source ~/.zshrc
 source "$ZSHRC"
-
-# Check if $ZSH_CUSTOM is set
-if [[ -z $ZSH_CUSTOM ]]; then
-  error '$ZSH_CUSTOM is not defined!'
-  exit 1
-fi
 
 # Remove symlink
 if [[ -L "$DIST" ]]; then
   log "Removing $DIST..."
   rm -f "$DIST"
 else
-  warning "$DIST is not present!"
+  DIST="$HOME/.zfunctions/prompt_spaceship_setup"
+  if [[ -L "DIST" ]]; then
+    log "Removing $DIST..."
+    rm -f "$DIST"
+  else
+    warning '"$DIST" is not present'
+  fi
 fi
 
 # Remove spaceship from .zshrc
-if grep -q "$DIST" "$ZSHRC"; then
+if grep -q "spaceship" "$ZSHRC"; then
   log "Removing Spaceship from $ZSHRC"
-  sed -i '' "/source .*\/themes\/spaceship.zsh-theme/d" "$ZSHRC"
+  sed -i '' '/prompt/d' $ZSHRC
+  sed -i '' '/SPACESHIP/d' $ZSHRC
+  sed -i '' '/.zfunctions/d' $ZSHRC
 else
-  warning "$DIST is not sourced in $ZSHRC!"
-fi
-
-# Change theme to default one
-if grep -q "ZSH_THEME=.*" "$ZSHRC"; then
-  log 'Attempting to change theme from "spaceship" to "robbyrussell"'
-  sed -i '' 's/ZSH_THEME=.spaceship./ZSH_THEME="robbyrussell"/g' "$ZSHRC"
-else
-  warning '"spaceship" was not set as theme!'
+  warning "Spaceship configuration not found in $ZSHRC!"
 fi
 
 success "Done! Spaceship is successfuly removed! Please, reload your terminal."


### PR DESCRIPTION
This removes the `oh-my-zsh` dependency for `git` section. `git_brach` section is shamelessly copied from `oh-my-zsh` and `git_status` section has been updated to identify more combinations of status indicators.

Below table shows the _regex_ used to identify relevant indicators from `git status`

|  Status   |                 OMZ                 |             Extended              |
| :-------: | :---------------------------------: | :-------------------------------: |
| Untracked |                `^\?\?`                 |             No Change             |
|   Added   |            `^A `, `^M `             |        `^A [ MDAU]`, `^UA`         |
| Modified  |         `^ M`, `^AM`, `^ T`         |      `^M[ MD]`, `^[ MARC]M `      |
|  Renamed  |                `^R `                |             `^R[ MD]`             |
|  Deleted  |         `^ D`, `^D`, `^AD`          |     `^[MARCDU] D`, `^D[ UM]`      |
|  Stashed  | `git rev-parse --verify refs/stash` |             No Change             |
| Unmerged  |                `^UU`                | `^U[UDA]`, `^AA`, `^DD`, `^[DA]U` |
|   Ahead   |        `^## [^ ]\+ .*ahead`         |             No Change             |
|  Behind   |        `^## [^ ]\+ .*behind`        |             No Change             |
| Diverged  |       `^## [^ ]\+ .*diverged`       |             No Change             |

----
Close #101 