### PR TITLE
trigger golang on Gopkg.toml or Gopkg.lock

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -753,7 +753,7 @@ spaceship_golang() {
   [[ $SPACESHIP_GOLANG_SHOW == false ]] && return
 
   # If there are Go-specific files in current directory
-  [[ -d Godeps || -f glide.yaml || -n *.go(#qN) ]] || return
+  [[ -d Godeps || -f glide.yaml || -n *.go(#qN) || -f Gopkg.yml || Gopkg.lock ]] || return
 
   _exists go || return
 


### PR DESCRIPTION
The Go community is working on an official Go package manager, [`dep`](https://github.com/golang/dep), which generates a `Gopkg.toml` and `Gopkg.lock` files.

This PR extends the Golang prompt in spaceship and triggers Golang prompt if `Gopkg.toml` or `Gopkg.lock` files exist, beyond the `Godeps` dir or `glide.yaml` file.

Also, not all Go projects have `*.go` files at the root of the project.

Hope this helps.