### PR TITLE
Battery informations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Currently it shows:
 * Current Python pyenv (`🐍`).
 * Current .NET SDK version, through dotnet-cli (`.NET`).
 * Current Ember.js version, through ember-cli (`🐹`).
+* Current battery level and status (`🔋 `):
+  * `⇡` - charging;
+  * `⇣` - discharging;
+  * `•` - fully charged;
 * Current Vi-mode mode ([with handy aliases for temporarily enabling](#vi-mode-vi_mode)).
 * Indicator for jobs in the background (`✦`).
 * Optional exit-code of last command ([how to enable](#exit-code-exit_code)).
@@ -178,6 +182,7 @@ SPACESHIP_PROMPT_ORDER=(
   pyenv         # Pyenv section
   dotnet        # .NET section
   ember         # Ember.js section
+  battery       # Battery level and status
   exec_time     # Execution time
   line_sep      # Line break
   vi_mode       # Vi-mode indicator
@@ -520,6 +525,21 @@ Ember.js section is shown only in directories that contain a `ember-cli-build.js
 | `SPACESHIP_EMBER_SYMBOL` | `🐹 ` | Character to be shown before Ember.js version |
 | `SPACESHIP_EMBER_COLOR` | `210` | Color of Ember.js section |
 
+### Battery (`battery`)
+
+By default, Battery section is shown only if battery level is below `SPACESHIP_BATTERY_THRESHOLD` (default: 10%) or it's fully charged.  It can be made always visible by setting `SPACESHIP_BATTERY_ALWAYS_SHOW=true`.
+
+| Variable | Default | Meaning |
+| :------- | :-----: | ------- |
+| `SPACESHIP_BATTERY_SHOW` | `true` | Show battery section or not |
+| `SPACESHIP_BATTERY_ALWAYS_SHOW` | `false` | Always show battery section or not |
+| `SPACESHIP_BATTERY_PREFIX` | `🔋 ` | Prefix before battery section |
+| `SPACESHIP_BATTERY_SUFFIX` | `SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after battery section |
+| `SPACESHIP_BATTERY_CHARGING_SYMBOL` | `⇡` | Character to be shown if battery is charging |
+| `SPACESHIP_BATTERY_DISCHARGING_SYMBOL` | `⇣` | Character to be shown if battery is discharging |
+| `SPACESHIP_BATTERY_FULL_SYMBOL` | `•` | Character to be shown if battery is full |
+| `SPACESHIP_BATTERY_THRESHOLD` | 10 | Battery level below which battery section will be shown |
+
 ### Execution time (`exec_time`)
 
 Execution time of the last command. Will be displayed if it exceeds the set threshold of time.
@@ -608,6 +628,7 @@ SPACESHIP_PROMPT_ORDER=(
   pyenv
   dotnet
   ember
+  battery
   exec_time
   line_sep
   vi_mode
@@ -814,6 +835,16 @@ SPACESHIP_EMBER_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"
 SPACESHIP_EMBER_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
 SPACESHIP_EMBER_SYMBOL="🐹 "
 SPACESHIP_EMBER_COLOR="210"
+
+# BATTERY
+SPACESHIP_BATTERY_SHOW=true
+SPACESHIP_BATTERY_ALWAYS_SHOW=false
+SPACESHIP_BATTERY_PREFIX="🔋 "
+SPACESHIP_BATTERY_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
+SPACESHIP_BATTERY_CHARGING_SYMBOL="⇡"
+SPACESHIP_BATTERY_DISCHARGING_SYMBOL="⇣"
+SPACESHIP_BATTERY_FULL_SYMBOL="•"
+SPACESHIP_BATTERY_THRESHOLD=10
 
 # VI_MODE
 SPACESHIP_VI_MODE_SHOW=true

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -38,6 +38,7 @@ if [ ! -n "$SPACESHIP_PROMPT_ORDER" ]; then
     pyenv
     dotnet
     ember
+    battery
     exec_time
     line_sep
     vi_mode
@@ -63,6 +64,16 @@ SPACESHIP_TIME_SUFFIX="${SPACESHIP_TIME_SUFFIX:="$SPACESHIP_PROMPT_DEFAULT_SUFFI
 SPACESHIP_TIME_FORMAT="${SPACESHIP_TIME_FORMAT:=false}"
 SPACESHIP_TIME_12HR="${SPACESHIP_TIME_12HR:=false}"
 SPACESHIP_TIME_COLOR="${SPACESHIP_TIME_COLOR:="yellow"}"
+
+# BATTERY
+SPACESHIP_BATTERY_SHOW="${SPACESSHIP_BATTERY_SHOW:=true}"
+SPACESHIP_BATTERY_ALWAYS_SHOW="${SPACESHIP_BATTERY_ALWAYS_SHOW:=false}"
+SPACESHIP_BATTERY_PREFIX="${SPACESHIP_BATTERY_PREFFIX:="🔋 "}"
+SPACESHIP_BATTERY_SUFFIX="${SPACESHIP_BATTERY_SUFFIX:="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_BATTERY_CHARGING_SYMBOL="${SPACESHIP_BATTERY_CHARGING_SYMBOL:="⇡"}"
+SPACESHIP_BATTERY_DISCHARGING_SYMBOL="${SPACESHIP_BATTERY_DISCHARGING_SYMBOL:="⇣"}"
+SPACESHIP_BATTERY_FULL_SYMBOL="${SPACESHIP_BATTERY_FULL_SYMBOL:="•"}"
+SPACESHIP_BATTERY_THRESHOLD="${SPACESHIP_BATTERY_THRESHOLD:=10}"
 
 # USER
 SPACESHIP_USER_SHOW="${SPACESHIP_USER_SHOW:=true}"
@@ -403,6 +414,73 @@ spaceship_time() {
     "$SPACESHIP_TIME_PREFIX" \
     "$time_str" \
     "$SPACESHIP_TIME_SUFFIX"
+}
+
+# BATTERY
+spaceship_battery() {
+  [[ $SPACESHIP_BATTERY_SHOW == false ]] && return
+
+  local battery_data battery_percent battery_status battery_color
+
+  if _exists "pmset"; then
+    battery_data=$(pmset -g batt)
+
+    # Return if no internal battery
+    [[ -z $(echo $battery_data | grep "InternalBattery") ]] && return
+
+    battery_percent="$( echo $battery_data | grep -oE '[0-9]{1,3}%' )"
+    battery_status="$( echo $battery_data | awk -F '; *' 'NR==2 { print $2 }' )"
+  elif _exists "upower"; then
+    local battery=$(command upower -e | grep battery | head -1)
+
+    # Return if no battery
+    [[ -z $battery ]] && return
+
+    battery_data=$(upower -i $battery)
+    battery_percent="$( echo $battery_data | grep percentage | awk '{print $2}' )"
+    battery_status="$( echo $battery_data | grep state | awk '{print $2}' )"
+  elif _exists "acpi"; then
+    battery_data=$(acpi -b)
+
+    # Return if no battery
+    [[ -z $battery_data ]] && return
+    battery_percent="$( echo $battery_data | awk '{print $4}' )"
+    battery_status="$( echo $battery_data | awk '{print tolower($3)}' )"
+  fi
+
+  # Remove trailing % and symbols for comparison
+  battery_percent="$(echo $battery_percent | tr -d '%[,;]')"
+
+  # Change color based on battery percentage
+  if [[ $battery_percent == 100 || $battery_status =~ "(charged|full)" ]]; then
+    battery_color="green"
+  elif [[ $battery_percent < $SPACESHIP_BATTERY_THRESHOLD ]]; then
+    battery_color="red"
+  else
+    battery_color="yellow"
+  fi
+
+  # Battery indicator based on current status of battery
+  if [[ $battery_status == "charging" ]];then
+    battery_symbol="${SPACESHIP_BATTERY_CHARGING_SYMBOL}"
+  elif [[ $battery_status =~ "^[dD]ischarg.*" ]]; then
+    battery_symbol="${SPACESHIP_BATTERY_DISCHARGING_SYMBOL}"
+  else
+    battery_symbol="${SPACESHIP_BATTERY_FULL_SYMBOL}"
+  fi
+
+  # Show section only if either of follow is true
+  # - Always show is true
+  # - battery percentage is below the given limit (default: 10%)
+  # - Battery is fully charged
+  # Escape % for display since it's a special character in zsh prompt expansion
+  if [[ $SPACESHIP_BATTERY_ALWAYS_SHOW == true || $battery_percent < $SPACESHIP_BATTERY_THRESHOLD || $battery_status =~ "(charged|full)"  ]]; then
+    _prompt_section \
+      "$battery_color" \
+      "$SPACESHIP_BATTERY_PREFIX" \
+      "$battery_percent%%$battery_symbol" \
+      "$SPACESHIP_BATTERY_SUFFIX"
+  fi
 }
 
 # USER

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -65,16 +65,6 @@ SPACESHIP_TIME_FORMAT="${SPACESHIP_TIME_FORMAT:=false}"
 SPACESHIP_TIME_12HR="${SPACESHIP_TIME_12HR:=false}"
 SPACESHIP_TIME_COLOR="${SPACESHIP_TIME_COLOR:="yellow"}"
 
-# BATTERY
-SPACESHIP_BATTERY_SHOW="${SPACESSHIP_BATTERY_SHOW:=true}"
-SPACESHIP_BATTERY_ALWAYS_SHOW="${SPACESHIP_BATTERY_ALWAYS_SHOW:=false}"
-SPACESHIP_BATTERY_PREFIX="${SPACESHIP_BATTERY_PREFFIX:="🔋 "}"
-SPACESHIP_BATTERY_SUFFIX="${SPACESHIP_BATTERY_SUFFIX:="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
-SPACESHIP_BATTERY_CHARGING_SYMBOL="${SPACESHIP_BATTERY_CHARGING_SYMBOL:="⇡"}"
-SPACESHIP_BATTERY_DISCHARGING_SYMBOL="${SPACESHIP_BATTERY_DISCHARGING_SYMBOL:="⇣"}"
-SPACESHIP_BATTERY_FULL_SYMBOL="${SPACESHIP_BATTERY_FULL_SYMBOL:="•"}"
-SPACESHIP_BATTERY_THRESHOLD="${SPACESHIP_BATTERY_THRESHOLD:=10}"
-
 # USER
 SPACESHIP_USER_SHOW="${SPACESHIP_USER_SHOW:=true}"
 SPACESHIP_USER_PREFIX="${SPACESHIP_USER_PREFIX:="with "}"
@@ -256,6 +246,16 @@ SPACESHIP_EMBER_SUFFIX="${SPACESHIP_EMBER_SUFFIX:="$SPACESHIP_PROMPT_DEFAULT_SUF
 SPACESHIP_EMBER_SYMBOL="${SPACESHIP_EMBER_SYMBOL:="🐹 "}"
 SPACESHIP_EMBER_COLOR="${SPACESHIP_EMBER_COLOR:="210"}"
 
+# BATTERY
+SPACESHIP_BATTERY_SHOW="${SPACESSHIP_BATTERY_SHOW:=true}"
+SPACESHIP_BATTERY_ALWAYS_SHOW="${SPACESHIP_BATTERY_ALWAYS_SHOW:=false}"
+SPACESHIP_BATTERY_PREFIX="${SPACESHIP_BATTERY_PREFFIX:="🔋 "}"
+SPACESHIP_BATTERY_SUFFIX="${SPACESHIP_BATTERY_SUFFIX:="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
+SPACESHIP_BATTERY_CHARGING_SYMBOL="${SPACESHIP_BATTERY_CHARGING_SYMBOL:="⇡"}"
+SPACESHIP_BATTERY_DISCHARGING_SYMBOL="${SPACESHIP_BATTERY_DISCHARGING_SYMBOL:="⇣"}"
+SPACESHIP_BATTERY_FULL_SYMBOL="${SPACESHIP_BATTERY_FULL_SYMBOL:="•"}"
+SPACESHIP_BATTERY_THRESHOLD="${SPACESHIP_BATTERY_THRESHOLD:=10}"
+
 # EXECUTION TIME
 SPACESHIP_EXEC_TIME_SHOW="${SPACESHIP_EXEC_TIME_SHOW:=true}"
 SPACESHIP_EXEC_TIME_PREFIX="${SPACESHIP_EXEC_TIME_PREFIX:="took "}"
@@ -414,73 +414,6 @@ spaceship_time() {
     "$SPACESHIP_TIME_PREFIX" \
     "$time_str" \
     "$SPACESHIP_TIME_SUFFIX"
-}
-
-# BATTERY
-spaceship_battery() {
-  [[ $SPACESHIP_BATTERY_SHOW == false ]] && return
-
-  local battery_data battery_percent battery_status battery_color
-
-  if _exists "pmset"; then
-    battery_data=$(pmset -g batt)
-
-    # Return if no internal battery
-    [[ -z $(echo $battery_data | grep "InternalBattery") ]] && return
-
-    battery_percent="$( echo $battery_data | grep -oE '[0-9]{1,3}%' )"
-    battery_status="$( echo $battery_data | awk -F '; *' 'NR==2 { print $2 }' )"
-  elif _exists "upower"; then
-    local battery=$(command upower -e | grep battery | head -1)
-
-    # Return if no battery
-    [[ -z $battery ]] && return
-
-    battery_data=$(upower -i $battery)
-    battery_percent="$( echo $battery_data | grep percentage | awk '{print $2}' )"
-    battery_status="$( echo $battery_data | grep state | awk '{print $2}' )"
-  elif _exists "acpi"; then
-    battery_data=$(acpi -b)
-
-    # Return if no battery
-    [[ -z $battery_data ]] && return
-    battery_percent="$( echo $battery_data | awk '{print $4}' )"
-    battery_status="$( echo $battery_data | awk '{print tolower($3)}' )"
-  fi
-
-  # Remove trailing % and symbols for comparison
-  battery_percent="$(echo $battery_percent | tr -d '%[,;]')"
-
-  # Change color based on battery percentage
-  if [[ $battery_percent == 100 || $battery_status =~ "(charged|full)" ]]; then
-    battery_color="green"
-  elif [[ $battery_percent < $SPACESHIP_BATTERY_THRESHOLD ]]; then
-    battery_color="red"
-  else
-    battery_color="yellow"
-  fi
-
-  # Battery indicator based on current status of battery
-  if [[ $battery_status == "charging" ]];then
-    battery_symbol="${SPACESHIP_BATTERY_CHARGING_SYMBOL}"
-  elif [[ $battery_status =~ "^[dD]ischarg.*" ]]; then
-    battery_symbol="${SPACESHIP_BATTERY_DISCHARGING_SYMBOL}"
-  else
-    battery_symbol="${SPACESHIP_BATTERY_FULL_SYMBOL}"
-  fi
-
-  # Show section only if either of follow is true
-  # - Always show is true
-  # - battery percentage is below the given limit (default: 10%)
-  # - Battery is fully charged
-  # Escape % for display since it's a special character in zsh prompt expansion
-  if [[ $SPACESHIP_BATTERY_ALWAYS_SHOW == true || $battery_percent < $SPACESHIP_BATTERY_THRESHOLD || $battery_status =~ "(charged|full)"  ]]; then
-    _prompt_section \
-      "$battery_color" \
-      "$SPACESHIP_BATTERY_PREFIX" \
-      "$battery_percent%%$battery_symbol" \
-      "$SPACESHIP_BATTERY_SUFFIX"
-  fi
 }
 
 # USER
@@ -1014,6 +947,74 @@ spaceship_ember() {
     "$SPACESHIP_EMBER_PREFIX" \
     "${SPACESHIP_EMBER_SYMBOL}${ember_version}" \
     "$SPACESHIP_EMBER_SUFFIX"
+}
+
+# BATTERY
+# Show section only if either of follow is true
+# - Always show is true
+# - battery percentage is below the given limit (default: 10%)
+# - Battery is fully charged
+# Escape % for display since it's a special character in zsh prompt expansion
+spaceship_battery() {
+  [[ $SPACESHIP_BATTERY_SHOW == false ]] && return
+
+  local battery_data battery_percent battery_status battery_color
+
+  if _exists pmset; then
+    battery_data=$(pmset -g batt)
+
+    # Return if no internal battery
+    [[ -z $(echo $battery_data | grep "InternalBattery") ]] && return
+
+    battery_percent="$( echo $battery_data | grep -oE '[0-9]{1,3}%' )"
+    battery_status="$( echo $battery_data | awk -F '; *' 'NR==2 { print $2 }' )"
+  elif _exists upower; then
+    local battery=$(command upower -e | grep battery | head -1)
+
+    # Return if no battery
+    [[ -z $battery ]] && return
+
+    battery_data=$(upower -i $battery)
+    battery_percent="$( echo $battery_data | grep percentage | awk '{print $2}' )"
+    battery_status="$( echo $battery_data | grep state | awk '{print $2}' )"
+  elif _exists acpi; then
+    battery_data=$(acpi -b)
+
+    # Return if no battery
+    [[ -z $battery_data ]] && return
+    battery_percent="$( echo $battery_data | awk '{print $4}' )"
+    battery_status="$( echo $battery_data | awk '{print tolower($3)}' )"
+  fi
+
+  # Remove trailing % and symbols for comparison
+  battery_percent="$(echo $battery_percent | tr -d '%[,;]')"
+
+  # Change color based on battery percentage
+  if [[ $battery_percent == 100 || $battery_status =~ "(charged|full)" ]]; then
+    battery_color="green"
+  elif [[ $battery_percent < $SPACESHIP_BATTERY_THRESHOLD ]]; then
+    battery_color="red"
+  else
+    battery_color="yellow"
+  fi
+
+  # Battery indicator based on current status of battery
+  if [[ $battery_status == "charging" ]];then
+    battery_symbol="${SPACESHIP_BATTERY_CHARGING_SYMBOL}"
+  elif [[ $battery_status =~ "^[dD]ischarg.*" ]]; then
+    battery_symbol="${SPACESHIP_BATTERY_DISCHARGING_SYMBOL}"
+  else
+    battery_symbol="${SPACESHIP_BATTERY_FULL_SYMBOL}"
+  fi
+
+  # Escape % for display since it's a special character in zsh prompt expansion
+  if [[ $SPACESHIP_BATTERY_ALWAYS_SHOW == true || $battery_percent < $SPACESHIP_BATTERY_THRESHOLD || $battery_status =~ "(charged|full)"  ]]; then
+    _prompt_section \
+      "$battery_color" \
+      "$SPACESHIP_BATTERY_PREFIX" \
+      "$battery_percent%%$battery_symbol" \
+      "$SPACESHIP_BATTERY_SUFFIX"
+  fi
 }
 
 # EXECUTION TIME


### PR DESCRIPTION
Looks like #61 is dead. 

So, reworked on battery section to fetch battery information using `pmset`,`upower` and `acpi`.  By default battery information is displayed when battery level is below `SPACESHIP_BATTERY_THRESHOLD` (default: 10%) or completely charged. But user can opt to  always display battery information by setting `SPACESHIP_BATTERY_SHOW_ALWAYS=true`. 

Different colors and indicators are used to represent battery level and battery status.

|          Battery level           | Color  |
| :------------------------------: | :----: |
|      100% or fully charged       | Green  |
| Below `THRESHOLD` (default: 10%) |  Red   |
|       Between 10% and 100%       | Yellow |

| Battery status | Indicator |
| :------------: | :-------: |
|    Charging    |    `⇡`    |
|  Discharging   |    `⇣`    |
| Fully Charged  |    `•`    |

`🔋`  is used as `PREFIX`, But it doesn't change color based on the battery level. If anyone have a better alternative, let me know. 

Read about using multiple batteries on laptops, I'm not familiar with such configuration. In that case with `upower, Only the first battery listed will be considered.

### Samples with `BATTERY_ALWAYS_SHOW=true`

#### In ubuntu using `upower`
![spaceship-battery-linux](https://user-images.githubusercontent.com/10276208/27770637-d47afaea-5f5f-11e7-9f8e-6ab73f752f5c.png)

#### In macOS using `pmset`
![spaceship-battery-mac](https://user-images.githubusercontent.com/10276208/27770638-d4924132-5f5f-11e7-9c17-d18b71d43c98.png)


PS : I haven't updated the docs, Will do as review is finished. 

Close #61.