### PR TITLE
Show Go version when in Go workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ Shows current version of Swift. Local version has more priority than global.
 
 ### Go (`golang`)
 
-Go section is shown only in directories that contain `Godeps`, or `glide.yaml`, or any other file with `.go` extension.
+Go section is shown only in directories that contain `Godeps`, `glide.yaml`, any other file with `.go` extension, or current directory is in the Go workspace defined in $GOPATH
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ Shows current version of Swift. Local version has more priority than global.
 
 ### Go (`golang`)
 
-Go section is shown only in directories that contain `Godeps`, `glide.yaml`, any other file with `.go` extension, or current directory is in the Go workspace defined in $GOPATH
+Go section is shown only in directories that contain `Godeps`, `glide.yaml`, any other file with `.go` extension, or when current directory is in the Go workspace defined in `$GOPATH`.
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -752,8 +752,8 @@ spaceship_swift() {
 spaceship_golang() {
   [[ $SPACESHIP_GOLANG_SHOW == false ]] && return
 
-  # If there are Go-specific files in current directory
-  [[ -d Godeps || -f glide.yaml || -n *.go(#qN) || -f Gopkg.yml || -f Gopkg.lock ]] || return
+  # If there are Go-specific files in current directory, or current directory is under the GOPATH
+  [[ -d Godeps || -f glide.yaml || -n *.go(#qN) || -f Gopkg.yml || -f Gopkg.lock || (-v GOPATH && $PWD =~ $GOPATH) ]] || return
 
   _exists go || return
 


### PR DESCRIPTION
When playing around with Go for a few days, I thought it might be nice to display the Go version when the current working directory is anywhere in the [Go workspace](https://golang.org/doc/code.html#Organization) as defined by $GOPATH