### PR TITLE
Add option to show rust toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ PHP section is shown only in directories that contain any file with `.php` exten
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
-| `SPACESHIP_PHP_SHOW` | true | Show PHP section |
+| `SPACESHIP_PHP_SHOW` | `true` | Show PHP section |
 | `SPACESHIP_PHP_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the PHP section |
 | `SPACESHIP_PHP_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the PHP section |
 | `SPACESHIP_PHP_SYMBOL` | `🐘 ` | Character to be shown before PHP version |
@@ -433,7 +433,9 @@ Rust section is shown only in directories that contain `Cargo.toml` or any other
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
-| `SPACESHIP_RUST_SHOW` | `true` | Shown current Rust version or not |
+| `SPACESHIP_RUST_SHOW` | `true` | Shown Rust section or not |
+| `SPACESHIP_RUST_SHOW_VERSION` | `true` | Shown current Rust version number or not |
+| `SPACESHIP_RUST_SHOW_TOOLCHAIN` | `false` | Shown current Rust toolchain or not |
 | `SPACESHIP_RUST_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the Rust section |
 | `SPACESHIP_RUST_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Rust section |
 | `SPACESHIP_RUST_SYMBOL` | `𝗥 ` | Character to be shown before Rust version |
@@ -769,6 +771,8 @@ SPACESHIP_PHP_COLOR="blue"
 
 # RUST
 SPACESHIP_RUST_SHOW=true
+SPACESHIP_RUST_SHOW_VERSION=true
+SPACESHIP_RUST_SHOW_TOOLCHAIN=false
 SPACESHIP_RUST_PREFIX="$SPACESHIP_PROMPT_DEFAULT_PREFIX"
 SPACESHIP_RUST_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
 SPACESHIP_RUST_SYMBOL="𝗥 "

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -192,6 +192,8 @@ SPACESHIP_PHP_COLOR="${SPACESHIP_PHP_COLOR:="blue"}"
 
 # RUST
 SPACESHIP_RUST_SHOW="${SPACESHIP_RUST_SHOW:=true}"
+SPACESHIP_RUST_SHOW_VERSION="${SPACESHIP_RUST_SHOW_VERSION:=true}"
+SPACESHIP_RUST_SHOW_TOOLCHAIN="${SPACESHIP_RUST_SHOW_TOOLCHAIN:=false}"
 SPACESHIP_RUST_PREFIX="${SPACESHIP_RUST_PREFIX:="$SPACESHIP_PROMPT_DEFAULT_PREFIX"}"
 SPACESHIP_RUST_SUFFIX="${SPACESHIP_RUST_SUFFIX:="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_RUST_SYMBOL="${SPACESHIP_RUST_SYMBOL:="𝗥 "}"
@@ -795,12 +797,14 @@ spaceship_rust() {
 
   _exists rustc || return
 
-  local rust_version=$(rustc --version | grep --colour=never -oE '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]')
+  local -a rust_version
+  [[ $SPACESHIP_RUST_SHOW_VERSION == false ]] || rust_version+="v$(rustc --version | grep --colour=never -oE '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]')"
+  [[ $SPACESHIP_RUST_SHOW_TOOLCHAIN == false ]] || rust_version+=$(rustc --version | grep --colour=never -oE '(stable|beta|nightly)' || echo stable)
 
   _prompt_section \
     "$SPACESHIP_RUST_COLOR" \
     "$SPACESHIP_RUST_PREFIX" \
-    "${SPACESHIP_RUST_SYMBOL}v${rust_version}" \
+    "${SPACESHIP_RUST_SYMBOL}${rust_version}" \
     "$SPACESHIP_RUST_SUFFIX"
 }
 


### PR DESCRIPTION
The current Rust toolchain is just as important as the actual version number, so I added an option to display it. The version number and toolchain can be toggled independently and I kept the default behavior unchanged (i.e. show the version but not the toolchain).

![2017-08-09-072538_1088x453_scrot](https://user-images.githubusercontent.com/5445049/29119513-692f3f98-7cd4-11e7-9a90-3f7f5b1c3381.png)
\* Ignore the missing `R` glyph; I need to fix my fonts!
