### PR TITLE
Fix globbing to exclude directories

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -602,7 +602,7 @@ spaceship_node() {
   [[ $SPACESHIP_NODE_SHOW == false ]] && return
 
   # Show NODE status only for JS-specific folders
-  [[ -f package.json || -d node_modules || -n *.js(#qN) ]] || return
+  [[ -f package.json || -d node_modules || -n *.js(#qN^/) ]] || return
 
   local node_version
 
@@ -632,7 +632,7 @@ spaceship_ruby() {
   [[ $SPACESHIP_RUBY_SHOW == false ]] && return
 
   # Show versions only for Ruby-specific folders
-  [[ -f Gemfile || -f Rakefile || -n *.rb(#qN) ]] || return
+  [[ -f Gemfile || -f Rakefile || -n *.rb(#qN^/) ]] || return
 
   local ruby_version
 
@@ -664,7 +664,7 @@ spaceship_elixir() {
   [[ $SPACESHIP_ELIXIR_SHOW == false ]] && return
 
   # Show versions only for Elixir-specific folders
-  [[ -f mix.exs || -n *.ex(#qN) || -n *.exs(#qN) ]] || return
+  [[ -f mix.exs || -n *.ex(#qN^/) || -n *.exs(#qN^/) ]] || return
 
   local elixir_version
 
@@ -753,7 +753,7 @@ spaceship_golang() {
   [[ $SPACESHIP_GOLANG_SHOW == false ]] && return
 
   # If there are Go-specific files in current directory
-  [[ -d Godeps || -f glide.yaml || -n *.go(#qN) || -f Gopkg.yml || -f Gopkg.lock ]] || return
+  [[ -d Godeps || -f glide.yaml || -n *.go(#qN^/) || -f Gopkg.yml || -f Gopkg.lock ]] || return
 
   _exists go || return
 
@@ -772,7 +772,7 @@ spaceship_php() {
   [[ $SPACESHIP_PHP_SHOW == false ]] && return
 
   # Show only if php files exist in current directory
-  [[ -n *.php(#qN) ]] || return
+  [[ -n *.php(#qN^/) ]] || return
 
   _exists php || return
 
@@ -791,7 +791,7 @@ spaceship_rust() {
   [[ $SPACESHIP_RUST_SHOW == false ]] && return
 
   # If there are Rust-specific files in current directory
-  [[ -f Cargo.toml || -n *.rs(#qN) ]] || return
+  [[ -f Cargo.toml || -n *.rs(#qN^/) ]] || return
 
   _exists rustc || return
 
@@ -830,7 +830,7 @@ spaceship_julia() {
   [[ $SPACESHIP_JULIA_SHOW == false ]] && return
 
   # If there are julia files in current directory
-  [[ -n *.jl(#qN) ]] || return
+  [[ -n *.jl(#qN^/) ]] || return
 
   _exists julia || return
 
@@ -886,7 +886,7 @@ spaceship_pyenv() {
   [[ $SPACESHIP_PYENV_SHOW == false ]] && return
 
   # Show NVM status only for Python-specific folders
-  [[ -f requirements.txt ]] || [[ -n *.py(#qN) ]] || return
+  [[ -f requirements.txt ]] || [[ -n *.py(#qN^/) ]] || return
 
   _exists pyenv || return # Do nothing if pyenv is not installed
 
@@ -905,7 +905,7 @@ spaceship_dotnet() {
   [[ $SPACESHIP_DOTNET_SHOW == false ]] && return
 
   # Show DOTNET status only for folders containing project.json, global.json, .csproj, .xproj or .sln files
-  [[ -f project.json || -f global.json || -n *.csproj(#qN) || -n *.xproj(#qN) || -n *.sln(#qN) ]] || return
+  [[ -f project.json || -f global.json || -n *.csproj(#qN^/) || -n *.xproj(#qN^/) || -n *.sln(#qN^/) ]] || return
 
   _exists dotnet || return
 


### PR DESCRIPTION
A tmp.rs directory, for example, triggers the display of the rust version in the prompt, despite clearly not being a rust file. As such, I added globbing qualifiers to exclude directories.