### PR TITLE
feat: replace basename with zsh :t modifier

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -876,7 +876,7 @@ spaceship_venv() {
   _prompt_section \
     "$SPACESHIP_VENV_COLOR" \
     "$SPACESHIP_VENV_PREFIX" \
-    "$(basename $VIRTUAL_ENV)" \
+    "$($VIRTUAL_ENV:t)" \
     "$SPACESHIP_VENV_SUFFIX"
 }
 


### PR DESCRIPTION
The zsh `:t` modifier does the same thing as `basename`, but executes
much faster because it's a builtin.

Fixes #173