### PR TITLE
Check $GOPATH without -v

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -766,7 +766,7 @@ spaceship_golang() {
   [[ $SPACESHIP_GOLANG_SHOW == false ]] && return
 
   # If there are Go-specific files in current directory, or current directory is under the GOPATH
-  [[ -d Godeps || -f glide.yaml || -n *.go(#qN) || -f Gopkg.yml || -f Gopkg.lock || (-v GOPATH && $PWD =~ $GOPATH) ]] || return
+  [[ -d Godeps || -f glide.yaml || -n *.go(#qN) || -f Gopkg.yml || -f Gopkg.lock || ( $GOPATH && $PWD =~ $GOPATH ) ]] || return
 
   _exists go || return
 


### PR DESCRIPTION
https://github.com/denysdovhan/spaceship-zsh-theme/commit/55e1d77fa0f293c720771335cd3e42570e935780 breaks prompt. Fixed with direct checking for `$GOPATH`

![go condition breaks prompt](https://user-images.githubusercontent.com/10276208/29517859-9f63bafc-8694-11e7-8349-626e05979d92.png)

