### PR TITLE
Fix path modifier mistake

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -936,7 +936,7 @@ spaceship_venv() {
   _prompt_section \
     "$SPACESHIP_VENV_COLOR" \
     "$SPACESHIP_VENV_PREFIX" \
-    "$($VIRTUAL_ENV:t)" \
+    "$VIRTUAL_ENV:t" \
     "$SPACESHIP_VENV_SUFFIX"
 }
 


### PR DESCRIPTION
This is a follow-up to #188. This fixes a syntax error with the path
modifier.

Fixes #173