### PR TITLE
Fix package version regex to work with GNU grep

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -618,7 +618,7 @@ spaceship_package() {
   _exists npm || return
 
   # Grep and cut out package version
-  local package_version=$(grep -E '"version": "v?((\d)+\.){1,}' package.json | cut -d\" -f4 2> /dev/null)
+  local package_version=$(grep -E '"version": "v?(([[:digit:]])+\.){1,}' package.json | cut -d\" -f4 2> /dev/null)
 
   # Handle version not found
   if [ ! "$package_version" ]; then


### PR DESCRIPTION
It seems, that GNU grep, which comes with most of Linux distributions [does not have `\d` character class](https://www.gnu.org/software/grep/manual/grep.html#The-Backslash-Character-and-Special-Expressions) in its extended regex, thus interpreting the sequence as just letter `d`. However it can handle this class in perl-regex mode (with `-P` flag instead of `-E`). Unfortunately `-P` does not seem to be supported in the version of grep which comes with MacOS.

There is a bracket expression `[[:digit:]]` which seems to work with any grep's extended regex.