### PR TITLE
Add SPACESHIP_BATTERY_CHARGED_SHOW option

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ By default, Battery section is shown only if battery level is below `SPACESHIP_B
 | `SPACESHIP_BATTERY_DISCHARGING_SYMBOL` | `⇣` | Character to be shown if battery is discharging |
 | `SPACESHIP_BATTERY_FULL_SYMBOL` | `•` | Character to be shown if battery is full |
 | `SPACESHIP_BATTERY_THRESHOLD` | 10 | Battery level below which battery section will be shown |
+| `SPACESHIP_BATTERY_CHARGED_SHOW | `true` | Show battery section when battery is fully loaded |
 
 ### Vi-mode (`vi_mode`)
 

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -279,6 +279,7 @@ SPACESHIP_BATTERY_CHARGING_SYMBOL="${SPACESHIP_BATTERY_CHARGING_SYMBOL:="⇡"}"
 SPACESHIP_BATTERY_DISCHARGING_SYMBOL="${SPACESHIP_BATTERY_DISCHARGING_SYMBOL:="⇣"}"
 SPACESHIP_BATTERY_FULL_SYMBOL="${SPACESHIP_BATTERY_FULL_SYMBOL:="•"}"
 SPACESHIP_BATTERY_THRESHOLD="${SPACESHIP_BATTERY_THRESHOLD:=10}"
+SPACESHIP_BATTERY_CHARGED_SHOW="${SPACESHIP_BATTERY_CHARGED_SHOW:=true}"
 
 # VI_MODE
 SPACESHIP_VI_MODE_SHOW="${SPACESHIP_VI_MODE_SHOW:=true}"
@@ -1109,7 +1110,7 @@ spaceship_battery() {
   fi
 
   # Escape % for display since it's a special character in zsh prompt expansion
-  if [[ $SPACESHIP_BATTERY_ALWAYS_SHOW == true || $battery_percent -lt $SPACESHIP_BATTERY_THRESHOLD || $battery_status =~ "(charged|full)"  ]]; then
+  if [[ $SPACESHIP_BATTERY_ALWAYS_SHOW == true || $battery_percent -lt $SPACESHIP_BATTERY_THRESHOLD || ($SPACESHIP_BATTERY_CHARGED_SHOW == true && $battery_status =~ "(charged|full)")  ]]; then
     _prompt_section \
       "$battery_color" \
       "$SPACESHIP_BATTERY_PREFIX" \


### PR DESCRIPTION
The SPACESHIP_BATTERY_CHARGED_SHOW option, `true` by default, determines
whether the battery section is shown when battery is full.

Closes #204