### PR TITLE
Make it possible to hide Node and Ruby versions in $HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ If you use [n] as Node.js version manager, please, set `SPACESHIP_NODE_DEFAULT_V
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_NODE_SHOW` | `true` | Current Node.js section |
+| `SPACESHIP_NODE_SHOW_HOME` | `true` | Show Node.js section in `$HOME` |
 | `SPACESHIP_NODE_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Node.js section |
 | `SPACESHIP_NODE_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Node.js section |
 | `SPACESHIP_NODE_SYMBOL` | `⬢ ` | Character to be shown before Node.js version |
@@ -370,6 +371,7 @@ Ruby section is shown only in directories that contain `Gemfile`, or `Rakefile`,
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_RUBY_SHOW` | `true` | Show Ruby section |
+| `SPACESHIP_RUBY_SHOW_HOME` | `true` | Show Ruby section in `$HOME` |
 | `SPACESHIP_RUBY_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Ruby section |
 | `SPACESHIP_RUBY_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Ruby section |
 | `SPACESHIP_RUBY_SYMBOL` | `💎  ` | Character to be shown before Ruby version |

--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -143,6 +143,7 @@ SPACESHIP_PACKAGE_COLOR="${SPACESHIP_PACKAGE_COLOR:="red"}"
 
 # NODE
 SPACESHIP_NODE_SHOW="${SPACESHIP_NODE_SHOW:=true}"
+SPACESHIP_NODE_SHOW_HOME="${SPACESHIP_NODE_SHOW_HOME:=true}"
 SPACESHIP_NODE_PREFIX="${SPACESHIP_NODE_PREFIX:="$SPACESHIP_PROMPT_DEFAULT_PREFIX"}"
 SPACESHIP_NODE_SUFFIX="${SPACESHIP_NODE_SUFFIX:="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_NODE_SYMBOL="${SPACESHIP_NODE_SYMBOL:="⬢ "}"
@@ -151,6 +152,7 @@ SPACESHIP_NODE_COLOR="${SPACESHIP_NODE_COLOR:="green"}"
 
 # RUBY
 SPACESHIP_RUBY_SHOW="${SPACESHIP_RUBY_SHOW:=true}"
+SPACESHIP_RUBY_SHOW_HOME="${SPACESHIP_RUBY_SHOW_HOME:=true}"
 SPACESHIP_RUBY_PREFIX="${SPACESHIP_RUBY_PREFIX:="$SPACESHIP_PROMPT_DEFAULT_PREFIX"}"
 SPACESHIP_RUBY_SUFFIX="${SPACESHIP_RUBY_SUFFIX:="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_RUBY_SYMBOL="${SPACESHIP_RUBY_SYMBOL:="💎 "}"
@@ -648,6 +650,9 @@ spaceship_package() {
 spaceship_node() {
   [[ $SPACESHIP_NODE_SHOW == false ]] && return
 
+  # Do not show version in $HOME if disabled
+  [[ $SPACESHIP_NODE_SHOW_HOME == false && $PWD == $HOME ]] && return
+
   # Show NODE status only for JS-specific folders
   [[ -f package.json || -d node_modules || -n *.js(#qN^/) ]] || return
 
@@ -677,6 +682,9 @@ spaceship_node() {
 # Show current version of Ruby
 spaceship_ruby() {
   [[ $SPACESHIP_RUBY_SHOW == false ]] && return
+
+  # Do not show version in $HOME if disabled
+  [[ $SPACESHIP_RUBY_SHOW_HOME == false && $PWD == $HOME ]] && return
 
   # Show versions only for Ruby-specific folders
   [[ -f Gemfile || -f Rakefile || -n *.rb(#qN^/) ]] || return


### PR DESCRIPTION
This PR allows user to hide Node and Ruby versions when in $HOME directory.