### PR TITLE
enable force option to display user and host

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -452,7 +452,7 @@ spaceship_time() {
 spaceship_user() {
   [[ $SPACESHIP_USER_SHOW == false ]] && return
 
-  if [[ $LOGNAME != $USER ]] || [[ $UID == 0 ]] || [[ -n $SSH_CONNECTION ]]; then
+  if [[ $LOGNAME != $USER ]] || [[ $UID == 0 ]] || [[ -n $SSH_CONNECTION ]] || [[ $SPACESHIP_USER_SHOW == 'force' ]]; then
     local user_color
 
     if [[ $USER == 'root' ]]; then
@@ -474,7 +474,7 @@ spaceship_user() {
 spaceship_host() {
   [[ $SPACESHIP_HOST_SHOW == false ]] && return
 
-  [[ -n $SSH_CONNECTION ]] || return
+  [[ -n $SSH_CONNECTION ]] || [[ $SPACESHIP_HOST_SHOW == 'force' ]] || return
 
   _prompt_section \
     "$SPACESHIP_HOST_COLOR" \


### PR DESCRIPTION
**Proposal**
To always display user and host info regardless of ssh or current user profile.

add `force` option to `SPACESHIP_USER_SHOW` and `SPACESHIP_HOST_SHOW ` to display user and host info , even if not ssh or if user is same as `$LOGNAME`

