### PR TITLE
fix bug and improve spaceship_docker

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -901,9 +901,8 @@ spaceship_docker() {
   [[ -f Dockerfile || -f docker-compose.yml ]] || return
 
   # if docker daemon isn't running you'll get an error saying it can't connect
-  docker info 2>&1 | grep -q "Cannot connect" && return
-
-  local docker_version=$(docker version -f "{{.Server.Version}}")
+  local docker_version=$(docker version -f "{{.Server.Version}}" 2>/dev/null)
+  [[ -z $docker_version ]] && return
 
   if [[ -n $DOCKER_MACHINE_NAME ]]; then
     docker_version+=" via ($DOCKER_MACHINE_NAME)"


### PR DESCRIPTION
* `grep -q "Cannot connect"` is fragile. When it talks to the swarm cluster, it can get other error messages because of networking errors

* `docker info` is unused, so `docker version` is enough.