### PR TITLE
Make defining LS_COLORS configurable

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -309,6 +309,9 @@ SPACESHIP_AWS_SUFFIX="${SPACESHIP_AWS_SUFFIX:="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"
 SPACESHIP_AWS_SYMBOL="${SPACESHIP_AWS_SYMBOL:="☁️ "}"
 SPACESHIP_AWS_COLOR="${SPACESHIP_AWS_COLOR:="208"}"
 
+# LS_COLORS
+SPACESHIP_LSCOLORS_DEFINE="${SPACESHIP_LSCOLORS_DEFINE:=true}"
+
 # ------------------------------------------------------------------------------
 # HELPERS
 # Helpers for common used actions
@@ -1283,6 +1286,7 @@ spaceship_setup() {
 
   # LSCOLORS
   # Online editor: https://geoff.greer.fm/lscolors/
+  [[ $SPACESHIP_LSCOLORS_DEFINE == false ]] && return
   export LSCOLORS="Gxfxcxdxbxegedabagacab"
   export LS_COLORS='no=00:fi=00:di=01;34:ln=00;36:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=41;33;01:ex=00;32:ow=0;41:*.cmd=00;32:*.exe=01;32:*.com=01;32:*.bat=01;32:*.btm=01;32:*.dll=01;32:*.tar=00;31:*.tbz=00;31:*.tgz=00;31:*.rpm=00;31:*.deb=00;31:*.arj=00;31:*.taz=00;31:*.lzh=00;31:*.lzma=00;31:*.zip=00;31:*.zoo=00;31:*.z=00;31:*.Z=00;31:*.gz=00;31:*.bz2=00;31:*.tb2=00;31:*.tz2=00;31:*.tbz2=00;31:*.avi=01;35:*.bmp=01;35:*.fli=01;35:*.gif=01;35:*.jpg=01;35:*.jpeg=01;35:*.mng=01;35:*.mov=01;35:*.mpg=01;35:*.pcx=01;35:*.pbm=01;35:*.pgm=01;35:*.png=01;35:*.ppm=01;35:*.tga=01;35:*.tif=01;35:*.xbm=01;35:*.xpm=01;35:*.dl=01;35:*.gl=01;35:*.wmv=01;35:*.aiff=00;32:*.au=00;32:*.mid=00;32:*.mp3=00;32:*.ogg=00;32:*.voc=00;32:*.wav=00;32:*.patch=00;34:*.o=00;32:*.so=01;35:*.ko=01;31:*.la=00;33'
   # Zsh to use the same colors as ls


### PR DESCRIPTION
Here's why this is needed:

I use a [custom provider for LS_COLORS](https://github.com/trapd00r/LS_COLORS) which adds a lot more colors, so I don't want to use the `LS_COLORS` from this theme. However this theme overrides my definition.

You might ask, why don't I simply define my LS_COLORS after this theme is applied? The reason is, it is useful to define proper LS_COLORS in the very beginning of your zshrc, before plugins and themes are loaded, so that for example autocompletion plugin can use this variable and show suggestions in color. I use antigen, which defines both plugins and themes in one place, so I can't really put my own definition of LS_COLORS in between those lines.

I preserved the default value of `true`, so nobody will be affected by this change.