### PR TITLE
Fix command not found: git_current_branch

### DIFF
--- a/sections/git_branch.zsh
+++ b/sections/git_branch.zsh
@@ -30,5 +30,5 @@ spaceship_git_branch() {
 
   _prompt_section \
     "$SPACESHIP_GIT_BRANCH_COLOR" \
-    "$SPACESHIP_GIT_BRANCH_PREFIX$(git_current_branch)$SPACESHIP_GIT_BRANCH_SUFFIX"
+    "$SPACESHIP_GIT_BRANCH_PREFIX${git_current_branch}$SPACESHIP_GIT_BRANCH_SUFFIX"
 }


### PR DESCRIPTION
I am using zsh and prezto, which is why I wanted to use your 3.0 release in my configuration. This should be working as I read in your discussions in your Issues and PRs (e.g. #147 #148), but when I wanted to test this theme with my setup, there was still this error:

![screenshot_20171204_105544](https://user-images.githubusercontent.com/1507474/33546843-6822dc12-d8e2-11e7-8aa6-f895c0c51a1c.png)

There was still this error after I checked out the 3.0 branch. I replaced a call in git_branch.sh to use the local variables defined a few lines above the output of the function. By this way it is possible to display the correct branch where I am working on:

![image](https://user-images.githubusercontent.com/1507474/33546946-b9067170-d8e2-11e7-9dba-58321b66a488.png)

Great project, I like this theme, although it is a bit slow ;-)