### PR TITLE
Fix jobs count bug when cwd changes

### DIFF
--- a/sections/jobs.zsh
+++ b/sections/jobs.zsh
@@ -20,7 +20,7 @@ SPACESHIP_JOBS_COLOR="${SPACESHIP_JOBS_COLOR:="blue"}"
 spaceship_jobs() {
   [[ $SPACESHIP_JOBS_SHOW == false ]] && return
 
-  local jobs_amount=$(jobs -l | wc -l | xargs)
+  local jobs_amount=$( (jobs) | wc -l )
 
   [[ $jobs_amount -gt 0 ]] || return
   [[ $jobs_amount -eq 1 ]] && jobs_amount=''


### PR DESCRIPTION
Steps to reproduce:

```
❯ cd ~
❯ vim
Hit Ctrl+Z
Notice that there is no count of jobs, because only one job exists
❯ cd /tmp
Notice that count became two, even though we still have one job
```

Credits: https://unix.stackexchange.com/a/251870