### PR TITLE
git: fix current branch display

### DIFF
--- a/sections/git_branch.zsh
+++ b/sections/git_branch.zsh
@@ -30,5 +30,5 @@ spaceship_git_branch() {
 
   _prompt_section \
     "$SPACESHIP_GIT_BRANCH_COLOR" \
-    "$SPACESHIP_GIT_BRANCH_PREFIX$(git_current_branch)$SPACESHIP_GIT_BRANCH_SUFFIX"
+    "$SPACESHIP_GIT_BRANCH_PREFIX$git_current_branch$SPACESHIP_GIT_BRANCH_SUFFIX"
 }


### PR DESCRIPTION
$git_current_branch is a variable which is set earlier in this function and so it shouldn't be called.