### PR TITLE
Fix prompt setup when loaded using zsh prompt function

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -157,6 +157,14 @@ spaceship_ps2() {
 prompt_spaceship_setup() {
   autoload -Uz add-zsh-hook
 
+  # This variable is a magic variable used when loading themes with zsh's prompt
+  # function. It will ensure the proper prompt options are set.
+  prompt_opts=(cr percent sp subst)
+
+  # Borrowed from promptinit, sets the prompt options in case the prompt was not
+  # initialized via promptinit.
+  setopt noprompt{bang,cr,percent,subst} "prompt${^prompt_opts[@]}"
+
   # Add exec_time hooks
   add-zsh-hook preexec spaceship_exec_time_preexec_hook
   add-zsh-hook precmd spaceship_exec_time_precmd_hook


### PR DESCRIPTION
This is very similar to https://github.com/bhilburn/powerlevel9k/commit/f46c1bc11b4bd41be1f6feac61d1944891aa6830

It's based off code in zsh itself. `prompt_opts` are used when the prompt was loaded via promptinit/prompt and the setopt is a workaround for oh-my-zsh to ensure all the proper prompt options are set.