### PR TITLE
Fix missing git branch prefix

### DIFF
--- a/sections/git.zsh
+++ b/sections/git.zsh
@@ -3,13 +3,6 @@
 #
 
 # ------------------------------------------------------------------------------
-# Dependencies
-# ------------------------------------------------------------------------------
-
-source "$SPACESHIP_ROOT/sections/git_branch.zsh"
-source "$SPACESHIP_ROOT/sections/git_status.zsh"
-
-# ------------------------------------------------------------------------------
 # Configuration
 # ------------------------------------------------------------------------------
 
@@ -17,6 +10,13 @@ SPACESHIP_GIT_SHOW="${SPACESHIP_GIT_SHOW:=true}"
 SPACESHIP_GIT_PREFIX="${SPACESHIP_GIT_PREFIX:="on "}"
 SPACESHIP_GIT_SUFFIX="${SPACESHIP_GIT_SUFFIX:="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
 SPACESHIP_GIT_SYMBOL="${SPACESHIP_GIT_SYMBOL:=" "}"
+
+# ------------------------------------------------------------------------------
+# Dependencies
+# ------------------------------------------------------------------------------
+
+source "$SPACESHIP_ROOT/sections/git_branch.zsh"
+source "$SPACESHIP_ROOT/sections/git_status.zsh"
 
 # ------------------------------------------------------------------------------
 # Section


### PR DESCRIPTION
The `git_branch` dependency requires parent configuration `$SPACESHIP_GIT_SYMBOL` to be set at the time it is sourced so that it can correctly configure `$SPACESHIP_GIT_BRANCH_PREFIX`.

Today the default git symbol is simply not showing up in the `3.0`.