### PR TITLE
Add a space after the prompt symbol in the ps2 prompt

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -1263,7 +1263,7 @@ spaceship_prompt() {
 
 # PS2 - continuation interactive prompt
 spaceship_ps2() {
-  _prompt_section "yellow" $SPACESHIP_PROMPT_SYMBOL
+  _prompt_section "yellow" "$SPACESHIP_PROMPT_SYMBOL "
 }
 
 # Setup required environment variables


### PR DESCRIPTION
### Before
![virtualbox_linux mint 18 2_17_12_2017_20_12_41](https://user-images.githubusercontent.com/24731903/34082498-4c726772-e368-11e7-9bbc-43e21b9f9546.png)
### After
![virtualbox_linux mint 18 2_17_12_2017_20_22_21](https://user-images.githubusercontent.com/24731903/34082499-504772b6-e368-11e7-9b87-d2a422f3deb6.png)

I think this is already fixed in 3.0.