### PR TITLE
Allow not showing username on SSH connection

### DIFF
--- a/sections/user.zsh
+++ b/sections/user.zsh
@@ -6,6 +6,15 @@
 # Configuration
 # ------------------------------------------------------------------------------
 
+# --------------------------------------------------------------------------
+# | SPACESHIP_USER_SHOW | show username on local | show username on remote |
+# |---------------------+------------------------+-------------------------|
+# | false               | never                  | never                   |
+# | always              | always                 | always                  |
+# | true                | if needed              | always                  |
+# | needed              | if needed              | if needed               |
+# --------------------------------------------------------------------------
+
 SPACESHIP_USER_SHOW="${SPACESHIP_USER_SHOW=true}"
 SPACESHIP_USER_PREFIX="${SPACESHIP_USER_PREFIX="with "}"
 SPACESHIP_USER_SUFFIX="${SPACESHIP_USER_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
@@ -16,14 +25,13 @@ SPACESHIP_USER_COLOR_ROOT="${SPACESHIP_USER_COLOR_ROOT="red"}"
 # Section
 # ------------------------------------------------------------------------------
 
-# If user is root, then paint it in red. Otherwise, just print in yellow.
 spaceship_user() {
   [[ $SPACESHIP_USER_SHOW == false ]] && return
 
   if [[ $SPACESHIP_USER_SHOW == 'always' ]] \
   || [[ $LOGNAME != $USER ]] \
   || [[ $UID == 0 ]] \
-  || [[ -n $SSH_CONNECTION ]]
+  || [[ $SPACESHIP_USER_SHOW == true && -n $SSH_CONNECTION ]]
   then
     local user_color
 


### PR DESCRIPTION
This is useful to me because I often work on my remote machine via ssh, I use my own account and I don't need to see my username all the time.

The option name is open for suggestions, and I preserved the default behavior as it is today.

Fine with merging after 3.0 is out, I hope it happens soon though 😉 