### PR TITLE
README: Change ZSH_CUSTOM to ZSH_THEME to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For correct work you will first need:
 npm install -g spaceship-zsh-theme
 ```
 
-Done. This command should link `spaceship.zsh-theme` to your `$ZSH_CUSTOM/themes` and set `$ZSH_CUSTOM` to `"spaceship"`. Just reload your terminal.
+Done. This command should link `spaceship.zsh-theme` to your `$ZSH_CUSTOM/themes` and set `$ZSH_THEME` to `"spaceship"`. Just reload your terminal.
 
 **Tip:** Update Spaceship to new versions as any other package.
 


### PR DESCRIPTION
This confused me for a few minutes. I believe you mean `ZSH_THEME`, because setting it manually in my file (the auto-setter broke) changed the theme correctly. `ZSH_CUSTOM` doesn't seem to be the desired variable.