### PR TITLE
Fix missing icon in git status for deleted unstaged file

### DIFF
--- a/sections/git_status.zsh
+++ b/sections/git_status.zsh
@@ -64,7 +64,7 @@ spaceship_git_status() {
   fi
 
   # Check for deleted files
-  if $(echo "$INDEX" | command grep '^[MARCDU] D ' &> /dev/null); then
+  if $(echo "$INDEX" | command grep '^[MARCDU ]D ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_DELETED$git_status"
   elif $(echo "$INDEX" | command grep '^D[ UM] ' &> /dev/null); then
     git_status="$SPACESHIP_GIT_STATUS_DELETED$git_status"


### PR DESCRIPTION
- Delete a tracked file in git repo, do not `git add` it yet.
- Observe that git_status section doesn't detect it.