### PR TITLE
Don't check for deactivate to detect a virtualenv

### DIFF
--- a/spaceship.zsh
+++ b/spaceship.zsh
@@ -940,7 +940,7 @@ spaceship_venv() {
   [[ $SPACESHIP_VENV_SHOW == false ]] && return
 
   # Check if the current directory running via Virtualenv
-  [ -n "$VIRTUAL_ENV" ] && _exists deactivate || return
+  [ -n "$VIRTUAL_ENV" ] || return
 
   _prompt_section \
     "$SPACESHIP_VENV_COLOR" \


### PR DESCRIPTION
[Pipenv](https://docs.pipenv.org/) in fancy shell mode uses `pew workon` to activate the virtualenv which doesn't use the activate script, meaning the deactivate function is not defined and Spaceship fails to detect the virtualenv.