### PR TITLE
Make showing battery on 100% configurable

### DIFF
--- a/sections/battery.zsh
+++ b/sections/battery.zsh
@@ -11,8 +11,8 @@
 # |------------------------+-----------------+-----------------+---------------|
 # | false                  | hidden          | hidden          | hidden        |
 # | always                 | shown           | shown           | shown         |
-# | true                   | shown           | hidden          | hidden        |
-# | charged                | shown           | hidden          | shown         |
+# | true                   | shown           | hidden          | shown         |
+# | low                    | shown           | hidden          | hidden        |
 # ------------------------------------------------------------------------------
 
 SPACESHIP_BATTERY_SHOW="${SPACESHIP_BATTERY_SHOW=true}"
@@ -90,7 +90,7 @@ spaceship_battery() {
   # Escape % for display since it's a special character in zsh prompt expansion
   if [[ $SPACESHIP_BATTERY_SHOW == 'always' ||
         $battery_percent -lt $SPACESHIP_BATTERY_THRESHOLD ||
-        $SPACESHIP_BATTERY_SHOW == 'charged' && $battery_status =~ "(charged|full)" ]]; then
+        $SPACESHIP_BATTERY_SHOW == true && $battery_status =~ "(charged|full)" ]]; then
     spaceship::section \
       "$battery_color" \
       "$SPACESHIP_BATTERY_PREFIX" \

--- a/sections/battery.zsh
+++ b/sections/battery.zsh
@@ -6,6 +6,15 @@
 # Configuration
 # ------------------------------------------------------------------------------
 
+# ------------------------------------------------------------------------------
+# | SPACESHIP_BATTERY_SHOW | below threshold | above threshold | fully charged |
+# |------------------------+-----------------+-----------------+---------------|
+# | false                  | hidden          | hidden          | hidden        |
+# | always                 | shown           | shown           | shown         |
+# | true                   | shown           | hidden          | hidden        |
+# | charged                | shown           | hidden          | shown         |
+# ------------------------------------------------------------------------------
+
 SPACESHIP_BATTERY_SHOW="${SPACESHIP_BATTERY_SHOW=true}"
 SPACESHIP_BATTERY_PREFIX="${SPACESHIP_BATTERY_PREFIX=""}"
 SPACESHIP_BATTERY_SUFFIX="${SPACESHIP_BATTERY_SUFFIX="$SPACESHIP_PROMPT_DEFAULT_SUFFIX"}"
@@ -79,7 +88,9 @@ spaceship_battery() {
   fi
 
   # Escape % for display since it's a special character in zsh prompt expansion
-  if [[ $SPACESHIP_BATTERY_SHOW == 'always' || $battery_percent -lt $SPACESHIP_BATTERY_THRESHOLD || $battery_status =~ "(charged|full)"  ]]; then
+  if [[ $SPACESHIP_BATTERY_SHOW == 'always' ||
+        $battery_percent -lt $SPACESHIP_BATTERY_THRESHOLD ||
+        $SPACESHIP_BATTERY_SHOW == 'charged' && $battery_status =~ "(charged|full)" ]]; then
     spaceship::section \
       "$battery_color" \
       "$SPACESHIP_BATTERY_PREFIX" \


### PR DESCRIPTION
Fixes #204 
Closes #232 

Breaking change: by default the battery will not be shown on 100%.

Why: I don't use this module myself, but I find it very odd that by default the battery was shown on 100% (others [dislike this too](https://github.com/denysdovhan/spaceship-zsh-theme/issues/245#issuecomment-339090702)). This contradicts the purpose of this theme in general: to show only necessary info. Battery is almost drained is an important indicator, but battery at 100% is not an actionable thing at all, why show it then?