### PR TITLE
Use no-break whitespace in markdown docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,6 @@ Every additional section will slow down the prompt a little bit. If your section
 When updating documentation for your section, make sure the markdown document is being properly rendered by Github. Specifically, the following common pitfalls have already been discovered:
 
 * Empty inline code block ` ` will only be rendered if you put at least one non-breaking whitespace "&nbsp;" inside, like so: ``` ` ` ``` → ` `
-* Leading and trailing whitespaces in inline code blocks will be stripped, to preserve them use non-breaking whitespace "&nbsp;", like so: ``` `🚀 ` ``` → `🚀 `
+* Leading and trailing whitespaces in inline code blocks will be stripped, to indicate that a whitespace is present, use the middot symbol `·`, like so: ``` `🚀·` ``` → `🚀·`
 
 **Thanks for reading this contribution guide! Happy hacking!**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Please, keep this simple rules in mind while you're contributing to Spaceship.
 ## Setup
 
 1. **Fork** this repo (click the *fork* button)
-2. **Clone** your fork to your working machine (via `git clone `)
+2. **Clone** your fork to your working machine (via `git clone`)
 3. **Add and commit** your contributions
 4. **Push** your changes to your remote fork
 5. **Open a pull-request** to our primary repo
@@ -44,5 +44,12 @@ Every additional section will slow down the prompt a little bit. If your section
 
 * **Good:** check if command exists, check the value of environment variable
 * **Bad:** network requests, reading large files, etc
+
+### Documentation
+
+When updating documentation for your section, make sure the markdown document is being properly rendered by Github. Specifically, the following common pitfalls have already been discovered:
+
+- Empty inline code block `` will only be rendered if you put at least one space inside, like so: \` \` => ` `
+- Leading and trailing whitespaces in inline code blocks will be stripped, to preserve them use non-breaking whitespace "&nbsp;", like so: \`🚀&nbsp;\` => `🚀 `
 
 **Thanks for reading this contribution guide! Happy hacking!**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Please, keep this simple rules in mind while you're contributing to Spaceship.
 
 ## Setup
 
-1. **Fork** this repo (click the *fork* button)
+1. **Fork** this repo (click the _fork_ button)
 2. **Clone** your fork to your working machine (via `git clone`)
 3. **Add and commit** your contributions
 4. **Push** your changes to your remote fork
@@ -49,7 +49,7 @@ Every additional section will slow down the prompt a little bit. If your section
 
 When updating documentation for your section, make sure the markdown document is being properly rendered by Github. Specifically, the following common pitfalls have already been discovered:
 
-- Empty inline code block `` will only be rendered if you put at least one space inside, like so: \` \` => ` `
-- Leading and trailing whitespaces in inline code blocks will be stripped, to preserve them use non-breaking whitespace "&nbsp;", like so: \`🚀&nbsp;\` => `🚀 `
+* Empty inline code block `` will only be rendered if you put at least one non-breaking whitespace "&nbsp;" inside, like so: ``` `` ``` → ` `
+* Leading and trailing whitespaces in inline code blocks will be stripped, to preserve them use non-breaking whitespace "&nbsp;", like so: \`🚀&nbsp;\` → `🚀 `
 
 **Thanks for reading this contribution guide! Happy hacking!**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,6 @@ Every additional section will slow down the prompt a little bit. If your section
 When updating documentation for your section, make sure the markdown document is being properly rendered by Github. Specifically, the following common pitfalls have already been discovered:
 
 * Empty inline code block ` ` will only be rendered if you put at least one non-breaking whitespace "&nbsp;" inside, like so: ``` ` ` ``` → ` `
-* Leading and trailing whitespaces in inline code blocks will be stripped, to preserve them use non-breaking whitespace "&nbsp;", like so: \`🚀&nbsp;\` → `🚀 `
+* Leading and trailing whitespaces in inline code blocks will be stripped, to preserve them use non-breaking whitespace "&nbsp;", like so: ``` `🚀 ` ``` → `🚀 `
 
 **Thanks for reading this contribution guide! Happy hacking!**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Every additional section will slow down the prompt a little bit. If your section
 
 When updating documentation for your section, make sure the markdown document is being properly rendered by Github. Specifically, the following common pitfalls have already been discovered:
 
-* Empty inline code block ` ` will only be rendered if you put at least one non-breaking whitespace "&nbsp;" inside, like so: ``` ` ` ``` → ` `
-* Leading and trailing whitespaces in inline code blocks will be stripped, to indicate that a whitespace is present, use the middot symbol `·`, like so: ``` `🚀·` ``` → `🚀·`
+* Empty inline code block ` ` will only be rendered if you put at least one non-breaking whitespace "&nbsp;" inside, like so: `` ` ` `` → ` `
+* Leading and trailing whitespaces in inline code blocks will be stripped, to indicate that a whitespace is present, use the middot symbol `·`, like so: `` `🚀·` `` → `🚀·`
 
 **Thanks for reading this contribution guide! Happy hacking!**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Every additional section will slow down the prompt a little bit. If your section
 
 When updating documentation for your section, make sure the markdown document is being properly rendered by Github. Specifically, the following common pitfalls have already been discovered:
 
-* Empty inline code block `` will only be rendered if you put at least one non-breaking whitespace "&nbsp;" inside, like so: ``` `` ``` → ` `
+* Empty inline code block ` ` will only be rendered if you put at least one non-breaking whitespace "&nbsp;" inside, like so: ``` ` ` ``` → ` `
 * Leading and trailing whitespaces in inline code blocks will be stripped, to preserve them use non-breaking whitespace "&nbsp;", like so: \`🚀&nbsp;\` → `🚀 `
 
 **Thanks for reading this contribution guide! Happy hacking!**

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -152,7 +152,7 @@ Git section is consists with `git_branch` and `git_status` subsections. It is sh
 | :------- | :-----: | ------- |
 | `SPACESHIP_GIT_BRANCH_SHOW` | `true` | Show Git branch subsection |
 | `SPACESHIP_GIT_BRANCH_PREFIX` | `$SPACESHIP_GIT_SYMBOL` | Prefix before Git branch subsection |
-| `SPACESHIP_GIT_BRANCH_SUFFIX` | `` | Suffix after Git branch subsection |
+| `SPACESHIP_GIT_BRANCH_SUFFIX` | ` ` | Suffix after Git branch subsection |
 | `SPACESHIP_GIT_BRANCH_COLOR` | `magenta` | Color of Git branch subsection |
 
 #### Git status (`git_status`)
@@ -239,7 +239,7 @@ If you use [n] as Node.js version manager, please, set `SPACESHIP_NODE_DEFAULT_V
 | `SPACESHIP_NODE_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Node.js section |
 | `SPACESHIP_NODE_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Node.js section |
 | `SPACESHIP_NODE_SYMBOL` | `⬢ ` | Character to be shown before Node.js version |
-| `SPACESHIP_NODE_DEFAULT_VERSION` | `` | Node.js version to be treated as default (for [n] support) |
+| `SPACESHIP_NODE_DEFAULT_VERSION` | ` ` | Node.js version to be treated as default (for [n] support) |
 | `SPACESHIP_NODE_COLOR` | `green` | Color of Node.js section |
 
 ### Ruby (`ruby`)
@@ -263,7 +263,7 @@ Elixir section is shown only in directories that contain `mix.exs`, or any other
 | `SPACESHIP_ELIXIR_SHOW` | `true` | Show Elixir section |
 | `SPACESHIP_ELIXIR_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Elixir section |
 | `SPACESHIP_ELIXIR_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Elixir section |
-| `SPACESHIP_ELIXIR_DEFAULT_VERSION` | `` | Elixir version to be treated as default |
+| `SPACESHIP_ELIXIR_DEFAULT_VERSION` | ` ` | Elixir version to be treated as default |
 | `SPACESHIP_ELIXIR_SYMBOL` | `💧 ` | Character to be shown before Elixir version |
 | `SPACESHIP_ELIXIR_COLOR` | `magenta` | Color of Elixir section |
 
@@ -465,7 +465,7 @@ By default, Battery section is shown only if battery level is below `SPACESHIP_B
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_BATTERY_SHOW` | `true` | Show battery section or not (`true`, `false`, `always` or `low`) |
-| `SPACESHIP_BATTERY_PREFIX` | `` | Prefix before battery section |
+| `SPACESHIP_BATTERY_PREFIX` | ` ` | Prefix before battery section |
 | `SPACESHIP_BATTERY_SUFFIX` | `SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after battery section |
 | `SPACESHIP_BATTERY_SYMBOL_CHARGING` | `⇡` | Character to be shown if battery is charging |
 | `SPACESHIP_BATTERY_SYMBOL_DISCHARGING` | `⇣` | Character to be shown if battery is discharging |
@@ -488,7 +488,7 @@ This section shows mode indicator only when Vi-mode is enabled.
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_VI_MODE_SHOW` | `true` | Shown current Vi-mode or not |
-| `SPACESHIP_VI_MODE_PREFIX` | `` | Prefix before Vi-mode section |
+| `SPACESHIP_VI_MODE_PREFIX` | ` ` | Prefix before Vi-mode section |
 | `SPACESHIP_VI_MODE_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Vi-mode section |
 | `SPACESHIP_VI_MODE_INSERT` | `[I]` | Text to be shown when in insert mode |
 | `SPACESHIP_VI_MODE_NORMAL` | `[N]` | Text to be shown when in normal mode |
@@ -510,7 +510,7 @@ This section show only when there are active jobs in the background.
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_JOBS_SHOW` | `true` | Show background jobs indicator  |
-| `SPACESHIP_JOBS_PREFIX` | `` | Prefix before the jobs indicator |
+| `SPACESHIP_JOBS_PREFIX` | ` ` | Prefix before the jobs indicator |
 | `SPACESHIP_JOBS_SUFFIX` | ` ` | Suffix after the jobs indicator |
 | `SPACESHIP_JOBS_SYMBOL` | `✦` | Character to be shown when jobs are hiding |
 | `SPACESHIP_JOBS_COLOR` | `blue` | Color of background jobs section |
@@ -522,7 +522,7 @@ Disabled by default. Set `SPACESHIP_EXIT_CODE_SHOW` to `true` in your `.zshrc`, 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_EXIT_CODE_SHOW` | `false` | Show exit code of last command |
-| `SPACESHIP_EXIT_CODE_PREFIX` | `` | Prefix before exit code section |
+| `SPACESHIP_EXIT_CODE_PREFIX` | ` ` | Prefix before exit code section |
 | `SPACESHIP_EXIT_CODE_SUFFIX` | ` ` | Suffix after exit code section |
 | `SPACESHIP_EXIT_CODE_SYMBOL` | `✘` | Character to be shown before exit code |
 | `SPACESHIP_EXIT_CODE_COLOR` | `red` | Color of exit code section |

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -240,7 +240,7 @@ If you use [n] as Node.js version manager, please, set `SPACESHIP_NODE_DEFAULT_V
 | `SPACESHIP_NODE_SHOW` | `true` | Current Node.js section |
 | `SPACESHIP_NODE_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Node.js section |
 | `SPACESHIP_NODE_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Node.js section |
-| `SPACESHIP_NODE_SYMBOL` | `⬢ ` | Character to be shown before Node.js version |
+| `SPACESHIP_NODE_SYMBOL` | `⬢·` | Character to be shown before Node.js version |
 | `SPACESHIP_NODE_DEFAULT_VERSION` | ` ` | Node.js version to be treated as default (for [n] support) |
 | `SPACESHIP_NODE_COLOR` | `green` | Color of Node.js section |
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -4,6 +4,8 @@ You have ability to customize or disable specific elements of Spaceship. All opt
 
 Colors for sections can be [basic colors](https://wiki.archlinux.org/index.php/zsh#Colors) or [color codes](https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg).
 
+**Note:** the symbol `·` in this document represents a regular space character ` `, it is used to clearly indicate when an option default value starts or ends with a space.
+
 ### Order
 
 You can specify the order of prompt section using `SPACESHIP_PROMPT_ORDER` option. Use Zsh array syntax to define your own prompt order.
@@ -83,7 +85,7 @@ Disabled by default. Set `SPACESHIP_TIME_SHOW` to `true` in your `.zshrc`, if yo
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_TIME_SHOW` | `false` | Show time (set to `true` for enabling) |
-| `SPACESHIP_TIME_PREFIX` | `at ` | Prefix before time section |
+| `SPACESHIP_TIME_PREFIX` | `at·` | Prefix before time section |
 | `SPACESHIP_TIME_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after time section |
 | `SPACESHIP_TIME_COLOR` | `yellow` | Color of time section |
 | `SPACESHIP_TIME_FORMAT` | `false` | Custom date formatting [ZSH date formats](http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html#Date-and-time) |
@@ -96,7 +98,7 @@ By default, a username is shown only when it's not the same as `$LOGNAME`, when 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_USER_SHOW` | `true` | Show user section (`true`, `false`, `always` or `needed`) |
-| `SPACESHIP_USER_PREFIX` | `with ` | Prefix before user section |
+| `SPACESHIP_USER_PREFIX` | `with·` | Prefix before user section |
 | `SPACESHIP_USER_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after user section |
 | `SPACESHIP_USER_COLOR` | `yellow` | Color of user section |
 | `SPACESHIP_USER_COLOR_ROOT` | `red` | Color of user section when it's root |
@@ -117,7 +119,7 @@ Hostname is shown only when you're connected via SSH unless you change this beha
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_HOST_SHOW` | `true` | Show host section (`true`, `false` or `always`) |
-| `SPACESHIP_HOST_PREFIX` | `at ` | Prefix before the connected SSH machine name |
+| `SPACESHIP_HOST_PREFIX` | `at·` | Prefix before the connected SSH machine name |
 | `SPACESHIP_HOST_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the connected SSH machine name |
 | `SPACESHIP_HOST_COLOR` | `blue` | Color of host section |
 | `SPACESHIP_HOST_COLOR_SSH` | `green` | Color of host in SSH connection |
@@ -129,7 +131,7 @@ Directory is always shown and truncated to the value of `SPACESHIP_DIR_TRUNC`. W
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_DIR_SHOW` | `true` | Show directory section |
-| `SPACESHIP_DIR_PREFIX` | `in ` | Prefix before current directory |
+| `SPACESHIP_DIR_PREFIX` | `in·` | Prefix before current directory |
 | `SPACESHIP_DIR_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after current directory |
 | `SPACESHIP_DIR_TRUNC` | `3` | Number of folders of cwd to show in prompt, 0 to show all |
 | `SPACESHIP_DIR_TRUNC_REPO` | `true` | While in `git` repo, show only root directory and folders inside it |
@@ -142,9 +144,9 @@ Git section is consists with `git_branch` and `git_status` subsections. It is sh
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_GIT_SHOW` | `true` | Show Git section |
-| `SPACESHIP_GIT_PREFIX` | `on ` | Prefix before Git section |
+| `SPACESHIP_GIT_PREFIX` | `on·` | Prefix before Git section |
 | `SPACESHIP_GIT_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Git section |
-| `SPACESHIP_GIT_SYMBOL` | ![ ](https://user-images.githubusercontent.com/3459374/34947621-4f324a92-fa13-11e7-9b99-cdba2cdda6b9.png) | Character to be shown before Git section (requires [powerline patched font][powerline]) |
+| `SPACESHIP_GIT_SYMBOL` | ![·](https://user-images.githubusercontent.com/3459374/34947621-4f324a92-fa13-11e7-9b99-cdba2cdda6b9.png) | Character to be shown before Git section (requires [powerline patched font][powerline]) |
 
 #### Git branch (`git_branch`)
 
@@ -162,7 +164,7 @@ Git status indicators is shown only when you have dirty repository.
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_GIT_STATUS_SHOW` | `true` | Show Git status subsection |
-| `SPACESHIP_GIT_STATUS_PREFIX` | ` [` | Prefix before Git status subsection |
+| `SPACESHIP_GIT_STATUS_PREFIX` | `·[` | Prefix before Git status subsection |
 | `SPACESHIP_GIT_STATUS_SUFFIX` | `]` | Suffix after Git status subsection |
 | `SPACESHIP_GIT_STATUS_COLOR` | `red` | Color of Git status subsection |
 | `SPACESHIP_GIT_STATUS_UNTRACKED` | `?` | Indicator for untracked changes |
@@ -183,9 +185,9 @@ Mercurial section is consists with `hg_branch` and `hg_status` subsections. It i
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_HG_SHOW` | `true` | Show Mercurial section |
-| `SPACESHIP_HG_PREFIX` | `on ` | Prefix before Mercurial section |
+| `SPACESHIP_HG_PREFIX` | `on·` | Prefix before Mercurial section |
 | `SPACESHIP_HG_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Mercurial section |
-| `SPACESHIP_HG_SYMBOL` | `☿ ` | Character to be shown before Mercurial section |
+| `SPACESHIP_HG_SYMBOL` | `☿·` | Character to be shown before Mercurial section |
 
 #### Mercurial branch (`hg_branch`)
 
@@ -222,9 +224,9 @@ Package version is shown when repository is a package (e.g. contains a `package.
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_PACKAGE_SHOW` | `true` | Show package version |
-| `SPACESHIP_PACKAGE_PREFIX` | `is ` | Prefix before package version section |
+| `SPACESHIP_PACKAGE_PREFIX` | `is·` | Prefix before package version section |
 | `SPACESHIP_PACKAGE_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after package version section |
-| `SPACESHIP_PACKAGE_SYMBOL` | `📦 ` | Character to be shown before package version |
+| `SPACESHIP_PACKAGE_SYMBOL` | `📦·` | Character to be shown before package version |
 | `SPACESHIP_PACKAGE_COLOR` | `red` | Color of package version section |
 
 ### Node.js (`node`)
@@ -251,7 +253,7 @@ Ruby section is shown only in directories that contain `Gemfile`, or `Rakefile`,
 | `SPACESHIP_RUBY_SHOW` | `true` | Show Ruby section |
 | `SPACESHIP_RUBY_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Ruby section |
 | `SPACESHIP_RUBY_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Ruby section |
-| `SPACESHIP_RUBY_SYMBOL` | `💎 ` | Character to be shown before Ruby version |
+| `SPACESHIP_RUBY_SYMBOL` | `💎·` | Character to be shown before Ruby version |
 | `SPACESHIP_RUBY_COLOR` | `red` | Color of Ruby section |
 
 ### Elixir (`elixir`)
@@ -264,7 +266,7 @@ Elixir section is shown only in directories that contain `mix.exs`, or any other
 | `SPACESHIP_ELIXIR_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Elixir section |
 | `SPACESHIP_ELIXIR_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Elixir section |
 | `SPACESHIP_ELIXIR_DEFAULT_VERSION` | ` ` | Elixir version to be treated as default |
-| `SPACESHIP_ELIXIR_SYMBOL` | `💧 ` | Character to be shown before Elixir version |
+| `SPACESHIP_ELIXIR_SYMBOL` | `💧·` | Character to be shown before Elixir version |
 | `SPACESHIP_ELIXIR_COLOR` | `magenta` | Color of Elixir section |
 
 ### Xcode (`xcode`)
@@ -290,7 +292,7 @@ Shows current version of Swift. Local version has more priority than global.
 | `SPACESHIP_SWIFT_SHOW_GLOBAL` | `false` | Global Swift version based on [swiftenv] |
 | `SPACESHIP_SWIFT_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the Swift section |
 | `SPACESHIP_SWIFT_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix to be shown before the Swift section |
-| `SPACESHIP_SWIFT_SYMBOL` | `🐦 ` | Character to be shown before Swift version |
+| `SPACESHIP_SWIFT_SYMBOL` | `🐦·` | Character to be shown before Swift version |
 | `SPACESHIP_SWIFT_COLOR` | `yellow` | Color of Swift section |
 
 ### Go (`golang`)
@@ -302,7 +304,7 @@ Go section is shown only in directories that contain `Godeps`, `glide.yaml`, any
 | `SPACESHIP_GOLANG_SHOW` | `true` | Shown current Go version or not |
 | `SPACESHIP_GOLANG_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the Go section |
 | `SPACESHIP_GOLANG_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Go section |
-| `SPACESHIP_GOLANG_SYMBOL` | `🐹 ` | Character to be shown before Go version |
+| `SPACESHIP_GOLANG_SYMBOL` | `🐹·` | Character to be shown before Go version |
 | `SPACESHIP_GOLANG_COLOR` | `cyan` | Color of Go section |
 
 ### PHP (`php`)
@@ -314,7 +316,7 @@ PHP section is shown only in directories that contain any file with `.php` exten
 | `SPACESHIP_PHP_SHOW` | true | Show PHP section |
 | `SPACESHIP_PHP_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the PHP section |
 | `SPACESHIP_PHP_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the PHP section |
-| `SPACESHIP_PHP_SYMBOL` | `🐘 ` | Character to be shown before PHP version |
+| `SPACESHIP_PHP_SYMBOL` | `🐘·` | Character to be shown before PHP version |
 | `SPACESHIP_PHP_COLOR` | `blue` | Color of PHP section |
 
 ### Rust (`rust`)
@@ -326,7 +328,7 @@ Rust section is shown only in directories that contain `Cargo.toml` or any other
 | `SPACESHIP_RUST_SHOW` | `true` | Shown current Rust version or not |
 | `SPACESHIP_RUST_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the Rust section |
 | `SPACESHIP_RUST_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Rust section |
-| `SPACESHIP_RUST_SYMBOL` | `𝗥 ` | Character to be shown before Rust version |
+| `SPACESHIP_RUST_SYMBOL` | `𝗥·` | Character to be shown before Rust version |
 | `SPACESHIP_RUST_COLOR` | `red` | Color of Rust section |
 
 ### Haskell (`haskell`)
@@ -350,7 +352,7 @@ Julia section is shown only in directories that contain file with `.jl` extensio
 | `SPACESHIP_JULIA_SHOW` | `true` | Shown current Julia version or not |
 | `SPACESHIP_JULIA_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the Julia section |
 | `SPACESHIP_JULIA_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Julia section |
-| `SPACESHIP_JULIA_SYMBOL` | `ஃ ` | Character to be shown before Julia version |
+| `SPACESHIP_JULIA_SYMBOL` | `ஃ·` | Character to be shown before Julia version |
 | `SPACESHIP_JULIA_COLOR` | `green` | Color of Julia section |
 
 ### Docker (`docker`)
@@ -362,7 +364,7 @@ Docker section is shown only in directories that contain `Dockerfile` or `docker
 | `SPACESHIP_DOCKER_SHOW` | `true` | Show current Docker version and connected docker-machine or not |
 | `SPACESHIP_DOCKER_PREFIX` | `on ` | Prefix before the Docker section |
 | `SPACESHIP_DOCKER_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Docker section |
-| `SPACESHIP_DOCKER_SYMBOL` | `🐳 ` | Character to be shown before Docker version |
+| `SPACESHIP_DOCKER_SYMBOL` | `🐳·` | Character to be shown before Docker version |
 | `SPACESHIP_DOCKER_COLOR` | `cyan` | Color of Docker section |
 
 ### Amazon Web Services (AWS) (`aws`)
@@ -372,9 +374,9 @@ Shows selected Amazon Web Services profile using '[named profiles](http://docs.a
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_AWS_SHOW` | `true` | Show current selected AWS-cli profile or not |
-| `SPACESHIP_AWS_PREFIX` | `using ` | Prefix before the AWS section |
+| `SPACESHIP_AWS_PREFIX` | `using·` | Prefix before the AWS section |
 | `SPACESHIP_AWS_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the AWS section |
-| `SPACESHIP_AWS_SYMBOL` | `☁️ ` | Character to be shown before AWS profile |
+| `SPACESHIP_AWS_SYMBOL` | `☁️·` | Character to be shown before AWS profile |
 | `SPACESHIP_AWS_COLOR` | `208` | Color of AWS section |
 
 ### Virtualenv (`venv`)
@@ -407,7 +409,7 @@ pyenv section is shown only in directories that contain `requirements.txt` or an
 | `SPACESHIP_PYENV_SHOW` | `true` | Show current Pyenv version or not |
 | `SPACESHIP_PYENV_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the pyenv section |
 | `SPACESHIP_PYENV_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the pyenv section |
-| `SPACESHIP_PYENV_SYMBOL` | `🐍 ` | Character to be shown before Pyenv version |
+| `SPACESHIP_PYENV_SYMBOL` | `🐍·` | Character to be shown before Pyenv version |
 | `SPACESHIP_PYENV_COLOR` | `yellow` | Color of Pyenv section |
 
 ### .NET (`dotnet`)
@@ -419,7 +421,7 @@ pyenv section is shown only in directories that contain `requirements.txt` or an
 | `SPACESHIP_DOTNET_SHOW` | `true` | Current .NET section |
 | `SPACESHIP_DOTNET_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before .NET section |
 | `SPACESHIP_DOTNET_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after .NET section |
-| `SPACESHIP_DOTNET_SYMBOL` | `.NET ` | Character to be shown before .NET version |
+| `SPACESHIP_DOTNET_SYMBOL` | `.NET·` | Character to be shown before .NET version |
 | `SPACESHIP_DOTNET_COLOR` | `128` | Color of .NET section |
 
 ### Ember.js (`ember`)
@@ -431,7 +433,7 @@ Ember.js section is shown only in directories that contain a `ember-cli-build.js
 | `SPACESHIP_EMBER_SHOW` | `true` | Current Ember.js section |
 | `SPACESHIP_EMBER_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Ember.js section |
 | `SPACESHIP_EMBER_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Ember.js section |
-| `SPACESHIP_EMBER_SYMBOL` | `🐹 ` | Character to be shown before Ember.js version |
+| `SPACESHIP_EMBER_SYMBOL` | `🐹·` | Character to be shown before Ember.js version |
 | `SPACESHIP_EMBER_COLOR` | `210` | Color of Ember.js section |
 
 ### Kubectl context (`kubecontext`)
@@ -441,9 +443,9 @@ Shows the active kubectl context.
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_KUBECONTEXT_SHOW` | `true` | Current Kubectl context section |
-| `SPACESHIP_KUBECONTEXT_PREFIX` | `at ` | Prefix before Kubectl context section |
+| `SPACESHIP_KUBECONTEXT_PREFIX` | `at·` | Prefix before Kubectl context section |
 | `SPACESHIP_KUBECONTEXT_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Kubectl context section |
-| `SPACESHIP_KUBECONTEXT_SYMBOL` | `☸️ ` | Character to be shown before Kubectl context |
+| `SPACESHIP_KUBECONTEXT_SYMBOL` | `☸️·` | Character to be shown before Kubectl context |
 | `SPACESHIP_KUBECONTEXT_COLOR` | `cyan` | Color of Kubectl context section |
 
 ### Execution time (`exec_time`)
@@ -453,7 +455,7 @@ Execution time of the last command. Will be displayed if it exceeds the set thre
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_EXEC_TIME_SHOW` | `true` | Show execution time |
-| `SPACESHIP_EXEC_TIME_PREFIX` | `took ` | Prefix before execution time section |
+| `SPACESHIP_EXEC_TIME_PREFIX` | `took·` | Prefix before execution time section |
 | `SPACESHIP_EXEC_TIME_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after execution time section |
 | `SPACESHIP_EXEC_TIME_COLOR` | `yellow` | Color of execution time section |
 | `SPACESHIP_EXEC_TIME_ELAPSED` | `2` | The minimum number of seconds for showing execution time section |

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -63,14 +63,14 @@ This group of options defines a behaviour of prompt and standard parameters for 
 | `SPACESHIP_PROMPT_PREFIXES_SHOW` | `true` | Show prefixes before prompt sections or not |
 | `SPACESHIP_PROMPT_SUFFIXES_SHOW` | `true` | Show suffixes before prompt sections or not |
 | `SPACESHIP_PROMPT_DEFAULT_PREFIX` | `via ` | Default prefix for prompt sections |
-| `SPACESHIP_PROMPT_DEFAULT_SUFFIX` | ` ` | Default suffix for prompt section |
+| `SPACESHIP_PROMPT_DEFAULT_SUFFIX` | ` ` | Default suffix for prompt section |
 
 ### Char
 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
-| `SPACESHIP_CHAR_PREFIX` | ` ` | Prefix before prompt character |
-| `SPACESHIP_CHAR_SUFFIX` | ` ` | Suffix after prompt character |
+| `SPACESHIP_CHAR_PREFIX` | ` ` | Prefix before prompt character |
+| `SPACESHIP_CHAR_SUFFIX` | ` ` | Suffix after prompt character |
 | `SPACESHIP_CHAR_SYMBOL` | `➜ ` | Prompt character to be shown before any command |
 | `SPACESHIP_CHAR_COLOR_SUCCESS` | `green` | Color of prompt character if last command completes successfully |
 | `SPACESHIP_CHAR_COLOR_FAILURE` | `red` | Color of prompt character if last command returns non-zero exit-code |
@@ -83,7 +83,7 @@ Disabled by default. Set `SPACESHIP_TIME_SHOW` to `true` in your `.zshrc`, if yo
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_TIME_SHOW` | `false` | Show time (set to `true` for enabling) |
-| `SPACESHIP_TIME_PREFIX` | `at ` | Prefix before time section |
+| `SPACESHIP_TIME_PREFIX` | `at ` | Prefix before time section |
 | `SPACESHIP_TIME_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after time section |
 | `SPACESHIP_TIME_COLOR` | `yellow` | Color of time section |
 | `SPACESHIP_TIME_FORMAT` | `false` | Custom date formatting [ZSH date formats](http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html#Date-and-time) |
@@ -96,7 +96,7 @@ By default, a username is shown only when it's not the same as `$LOGNAME`, when 
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_USER_SHOW` | `true` | Show user section (`true`, `false`, `always` or `needed`) |
-| `SPACESHIP_USER_PREFIX` | `with ` | Prefix before user section |
+| `SPACESHIP_USER_PREFIX` | `with ` | Prefix before user section |
 | `SPACESHIP_USER_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after user section |
 | `SPACESHIP_USER_COLOR` | `yellow` | Color of user section |
 | `SPACESHIP_USER_COLOR_ROOT` | `red` | Color of user section when it's root |
@@ -117,7 +117,7 @@ Hostname is shown only when you're connected via SSH unless you change this beha
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_HOST_SHOW` | `true` | Show host section (`true`, `false` or `always`) |
-| `SPACESHIP_HOST_PREFIX` | `at ` | Prefix before the connected SSH machine name |
+| `SPACESHIP_HOST_PREFIX` | `at ` | Prefix before the connected SSH machine name |
 | `SPACESHIP_HOST_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the connected SSH machine name |
 | `SPACESHIP_HOST_COLOR` | `blue` | Color of host section |
 | `SPACESHIP_HOST_COLOR_SSH` | `green` | Color of host in SSH connection |
@@ -129,7 +129,7 @@ Directory is always shown and truncated to the value of `SPACESHIP_DIR_TRUNC`. W
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_DIR_SHOW` | `true` | Show directory section |
-| `SPACESHIP_DIR_PREFIX` | `in ` | Prefix before current directory |
+| `SPACESHIP_DIR_PREFIX` | `in ` | Prefix before current directory |
 | `SPACESHIP_DIR_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after current directory |
 | `SPACESHIP_DIR_TRUNC` | `3` | Number of folders of cwd to show in prompt, 0 to show all |
 | `SPACESHIP_DIR_TRUNC_REPO` | `true` | While in `git` repo, show only root directory and folders inside it |
@@ -142,9 +142,9 @@ Git section is consists with `git_branch` and `git_status` subsections. It is sh
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_GIT_SHOW` | `true` | Show Git section |
-| `SPACESHIP_GIT_PREFIX` | `on ` | Prefix before Git section |
+| `SPACESHIP_GIT_PREFIX` | `on ` | Prefix before Git section |
 | `SPACESHIP_GIT_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Git section |
-| `SPACESHIP_GIT_SYMBOL` | ![ ](https://user-images.githubusercontent.com/3459374/34947621-4f324a92-fa13-11e7-9b99-cdba2cdda6b9.png) | Character to be shown before Git section (requires [powerline patched font][powerline]) |
+| `SPACESHIP_GIT_SYMBOL` | ![ ](https://user-images.githubusercontent.com/3459374/34947621-4f324a92-fa13-11e7-9b99-cdba2cdda6b9.png) | Character to be shown before Git section (requires [powerline patched font][powerline]) |
 
 #### Git branch (`git_branch`)
 
@@ -162,7 +162,7 @@ Git status indicators is shown only when you have dirty repository.
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_GIT_STATUS_SHOW` | `true` | Show Git status subsection |
-| `SPACESHIP_GIT_STATUS_PREFIX` | ` [` | Prefix before Git status subsection |
+| `SPACESHIP_GIT_STATUS_PREFIX` | ` [` | Prefix before Git status subsection |
 | `SPACESHIP_GIT_STATUS_SUFFIX` | `]` | Suffix after Git status subsection |
 | `SPACESHIP_GIT_STATUS_COLOR` | `red` | Color of Git status subsection |
 | `SPACESHIP_GIT_STATUS_UNTRACKED` | `?` | Indicator for untracked changes |
@@ -183,9 +183,9 @@ Mercurial section is consists with `hg_branch` and `hg_status` subsections. It i
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_HG_SHOW` | `true` | Show Mercurial section |
-| `SPACESHIP_HG_PREFIX` | `on ` | Prefix before Mercurial section |
+| `SPACESHIP_HG_PREFIX` | `on ` | Prefix before Mercurial section |
 | `SPACESHIP_HG_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Mercurial section |
-| `SPACESHIP_HG_SYMBOL` | `☿ ` | Character to be shown before Mercurial section |
+| `SPACESHIP_HG_SYMBOL` | `☿ ` | Character to be shown before Mercurial section |
 
 #### Mercurial branch (`hg_branch`)
 
@@ -222,9 +222,9 @@ Package version is shown when repository is a package (e.g. contains a `package.
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_PACKAGE_SHOW` | `true` | Show package version |
-| `SPACESHIP_PACKAGE_PREFIX` | `is ` | Prefix before package version section |
+| `SPACESHIP_PACKAGE_PREFIX` | `is ` | Prefix before package version section |
 | `SPACESHIP_PACKAGE_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after package version section |
-| `SPACESHIP_PACKAGE_SYMBOL` | `📦 ` | Character to be shown before package version |
+| `SPACESHIP_PACKAGE_SYMBOL` | `📦 ` | Character to be shown before package version |
 | `SPACESHIP_PACKAGE_COLOR` | `red` | Color of package version section |
 
 ### Node.js (`node`)
@@ -251,7 +251,7 @@ Ruby section is shown only in directories that contain `Gemfile`, or `Rakefile`,
 | `SPACESHIP_RUBY_SHOW` | `true` | Show Ruby section |
 | `SPACESHIP_RUBY_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Ruby section |
 | `SPACESHIP_RUBY_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Ruby section |
-| `SPACESHIP_RUBY_SYMBOL` | `💎  ` | Character to be shown before Ruby version |
+| `SPACESHIP_RUBY_SYMBOL` | `💎 ` | Character to be shown before Ruby version |
 | `SPACESHIP_RUBY_COLOR` | `red` | Color of Ruby section |
 
 ### Elixir (`elixir`)
@@ -264,7 +264,7 @@ Elixir section is shown only in directories that contain `mix.exs`, or any other
 | `SPACESHIP_ELIXIR_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Elixir section |
 | `SPACESHIP_ELIXIR_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Elixir section |
 | `SPACESHIP_ELIXIR_DEFAULT_VERSION` | `` | Elixir version to be treated as default |
-| `SPACESHIP_ELIXIR_SYMBOL` | `💧  ` | Character to be shown before Elixir version |
+| `SPACESHIP_ELIXIR_SYMBOL` | `💧 ` | Character to be shown before Elixir version |
 | `SPACESHIP_ELIXIR_COLOR` | `magenta` | Color of Elixir section |
 
 ### Xcode (`xcode`)
@@ -290,7 +290,7 @@ Shows current version of Swift. Local version has more priority than global.
 | `SPACESHIP_SWIFT_SHOW_GLOBAL` | `false` | Global Swift version based on [swiftenv] |
 | `SPACESHIP_SWIFT_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the Swift section |
 | `SPACESHIP_SWIFT_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix to be shown before the Swift section |
-| `SPACESHIP_SWIFT_SYMBOL` | `🐦 ` | Character to be shown before Swift version |
+| `SPACESHIP_SWIFT_SYMBOL` | `🐦 ` | Character to be shown before Swift version |
 | `SPACESHIP_SWIFT_COLOR` | `yellow` | Color of Swift section |
 
 ### Go (`golang`)
@@ -302,7 +302,7 @@ Go section is shown only in directories that contain `Godeps`, `glide.yaml`, any
 | `SPACESHIP_GOLANG_SHOW` | `true` | Shown current Go version or not |
 | `SPACESHIP_GOLANG_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the Go section |
 | `SPACESHIP_GOLANG_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Go section |
-| `SPACESHIP_GOLANG_SYMBOL` | `🐹 ` | Character to be shown before Go version |
+| `SPACESHIP_GOLANG_SYMBOL` | `🐹 ` | Character to be shown before Go version |
 | `SPACESHIP_GOLANG_COLOR` | `cyan` | Color of Go section |
 
 ### PHP (`php`)
@@ -314,7 +314,7 @@ PHP section is shown only in directories that contain any file with `.php` exten
 | `SPACESHIP_PHP_SHOW` | true | Show PHP section |
 | `SPACESHIP_PHP_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the PHP section |
 | `SPACESHIP_PHP_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the PHP section |
-| `SPACESHIP_PHP_SYMBOL` | `🐘 ` | Character to be shown before PHP version |
+| `SPACESHIP_PHP_SYMBOL` | `🐘 ` | Character to be shown before PHP version |
 | `SPACESHIP_PHP_COLOR` | `blue` | Color of PHP section |
 
 ### Rust (`rust`)
@@ -326,7 +326,7 @@ Rust section is shown only in directories that contain `Cargo.toml` or any other
 | `SPACESHIP_RUST_SHOW` | `true` | Shown current Rust version or not |
 | `SPACESHIP_RUST_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the Rust section |
 | `SPACESHIP_RUST_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Rust section |
-| `SPACESHIP_RUST_SYMBOL` | `𝗥 ` | Character to be shown before Rust version |
+| `SPACESHIP_RUST_SYMBOL` | `𝗥 ` | Character to be shown before Rust version |
 | `SPACESHIP_RUST_COLOR` | `red` | Color of Rust section |
 
 ### Haskell (`haskell`)
@@ -350,7 +350,7 @@ Julia section is shown only in directories that contain file with `.jl` extensio
 | `SPACESHIP_JULIA_SHOW` | `true` | Shown current Julia version or not |
 | `SPACESHIP_JULIA_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the Julia section |
 | `SPACESHIP_JULIA_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Julia section |
-| `SPACESHIP_JULIA_SYMBOL` | `ஃ ` | Character to be shown before Julia version |
+| `SPACESHIP_JULIA_SYMBOL` | `ஃ ` | Character to be shown before Julia version |
 | `SPACESHIP_JULIA_COLOR` | `green` | Color of Julia section |
 
 ### Docker (`docker`)
@@ -362,7 +362,7 @@ Docker section is shown only in directories that contain `Dockerfile` or `docker
 | `SPACESHIP_DOCKER_SHOW` | `true` | Show current Docker version and connected docker-machine or not |
 | `SPACESHIP_DOCKER_PREFIX` | `on ` | Prefix before the Docker section |
 | `SPACESHIP_DOCKER_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Docker section |
-| `SPACESHIP_DOCKER_SYMBOL` | `🐳 ` | Character to be shown before Docker version |
+| `SPACESHIP_DOCKER_SYMBOL` | `🐳 ` | Character to be shown before Docker version |
 | `SPACESHIP_DOCKER_COLOR` | `cyan` | Color of Docker section |
 
 ### Amazon Web Services (AWS) (`aws`)
@@ -372,9 +372,9 @@ Shows selected Amazon Web Services profile using '[named profiles](http://docs.a
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_AWS_SHOW` | `true` | Show current selected AWS-cli profile or not |
-| `SPACESHIP_AWS_PREFIX` | `using ` | Prefix before the AWS section |
+| `SPACESHIP_AWS_PREFIX` | `using ` | Prefix before the AWS section |
 | `SPACESHIP_AWS_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the AWS section |
-| `SPACESHIP_AWS_SYMBOL` | `☁️ ` | Character to be shown before AWS profile |
+| `SPACESHIP_AWS_SYMBOL` | `☁️ ` | Character to be shown before AWS profile |
 | `SPACESHIP_AWS_COLOR` | `208` | Color of AWS section |
 
 ### Virtualenv (`venv`)
@@ -407,7 +407,7 @@ pyenv section is shown only in directories that contain `requirements.txt` or an
 | `SPACESHIP_PYENV_SHOW` | `true` | Show current Pyenv version or not |
 | `SPACESHIP_PYENV_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the pyenv section |
 | `SPACESHIP_PYENV_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the pyenv section |
-| `SPACESHIP_PYENV_SYMBOL` | `🐍 ` | Character to be shown before Pyenv version |
+| `SPACESHIP_PYENV_SYMBOL` | `🐍 ` | Character to be shown before Pyenv version |
 | `SPACESHIP_PYENV_COLOR` | `yellow` | Color of Pyenv section |
 
 ### .NET (`dotnet`)
@@ -419,7 +419,7 @@ pyenv section is shown only in directories that contain `requirements.txt` or an
 | `SPACESHIP_DOTNET_SHOW` | `true` | Current .NET section |
 | `SPACESHIP_DOTNET_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before .NET section |
 | `SPACESHIP_DOTNET_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after .NET section |
-| `SPACESHIP_DOTNET_SYMBOL` | `.NET ` | Character to be shown before .NET version |
+| `SPACESHIP_DOTNET_SYMBOL` | `.NET ` | Character to be shown before .NET version |
 | `SPACESHIP_DOTNET_COLOR` | `128` | Color of .NET section |
 
 ### Ember.js (`ember`)
@@ -431,7 +431,7 @@ Ember.js section is shown only in directories that contain a `ember-cli-build.js
 | `SPACESHIP_EMBER_SHOW` | `true` | Current Ember.js section |
 | `SPACESHIP_EMBER_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Ember.js section |
 | `SPACESHIP_EMBER_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Ember.js section |
-| `SPACESHIP_EMBER_SYMBOL` | `🐹 ` | Character to be shown before Ember.js version |
+| `SPACESHIP_EMBER_SYMBOL` | `🐹 ` | Character to be shown before Ember.js version |
 | `SPACESHIP_EMBER_COLOR` | `210` | Color of Ember.js section |
 
 ### Kubectl context (`kubecontext`)
@@ -441,9 +441,9 @@ Shows the active kubectl context.
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_KUBECONTEXT_SHOW` | `true` | Current Kubectl context section |
-| `SPACESHIP_KUBECONTEXT_PREFIX` | `at ` | Prefix before Kubectl context section |
+| `SPACESHIP_KUBECONTEXT_PREFIX` | `at ` | Prefix before Kubectl context section |
 | `SPACESHIP_KUBECONTEXT_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Kubectl context section |
-| `SPACESHIP_KUBECONTEXT_SYMBOL` | `☸️ ` | Character to be shown before Kubectl context |
+| `SPACESHIP_KUBECONTEXT_SYMBOL` | `☸️ ` | Character to be shown before Kubectl context |
 | `SPACESHIP_KUBECONTEXT_COLOR` | `cyan` | Color of Kubectl context section |
 
 ### Execution time (`exec_time`)
@@ -453,7 +453,7 @@ Execution time of the last command. Will be displayed if it exceeds the set thre
 | Variable | Default | Meaning |
 | :------- | :-----: | ------- |
 | `SPACESHIP_EXEC_TIME_SHOW` | `true` | Show execution time |
-| `SPACESHIP_EXEC_TIME_PREFIX` | `took ` | Prefix before execution time section |
+| `SPACESHIP_EXEC_TIME_PREFIX` | `took ` | Prefix before execution time section |
 | `SPACESHIP_EXEC_TIME_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after execution time section |
 | `SPACESHIP_EXEC_TIME_COLOR` | `yellow` | Color of execution time section |
 | `SPACESHIP_EXEC_TIME_ELAPSED` | `2` | The minimum number of seconds for showing execution time section |
@@ -511,7 +511,7 @@ This section show only when there are active jobs in the background.
 | :------- | :-----: | ------- |
 | `SPACESHIP_JOBS_SHOW` | `true` | Show background jobs indicator  |
 | `SPACESHIP_JOBS_PREFIX` | `` | Prefix before the jobs indicator |
-| `SPACESHIP_JOBS_SUFFIX` | ` ` | Suffix after the jobs indicator |
+| `SPACESHIP_JOBS_SUFFIX` | ` ` | Suffix after the jobs indicator |
 | `SPACESHIP_JOBS_SYMBOL` | `✦` | Character to be shown when jobs are hiding |
 | `SPACESHIP_JOBS_COLOR` | `blue` | Color of background jobs section |
 
@@ -523,7 +523,7 @@ Disabled by default. Set `SPACESHIP_EXIT_CODE_SHOW` to `true` in your `.zshrc`, 
 | :------- | :-----: | ------- |
 | `SPACESHIP_EXIT_CODE_SHOW` | `false` | Show exit code of last command |
 | `SPACESHIP_EXIT_CODE_PREFIX` | `` | Prefix before exit code section |
-| `SPACESHIP_EXIT_CODE_SUFFIX` | ` ` | Suffix after exit code section |
+| `SPACESHIP_EXIT_CODE_SUFFIX` | ` ` | Suffix after exit code section |
 | `SPACESHIP_EXIT_CODE_SYMBOL` | `✘` | Character to be shown before exit code |
 | `SPACESHIP_EXIT_CODE_COLOR` | `red` | Color of exit code section |
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -279,7 +279,7 @@ Shows current version of Xcode. Local version has more priority than global.
 | `SPACESHIP_XCODE_SHOW_GLOBAL` | `true` | Global Xcode version based on [xcenv] |
 | `SPACESHIP_XCODE_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before Xcode section |
 | `SPACESHIP_XCODE_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after Xcode section |
-| `SPACESHIP_XCODE_SYMBOL` | `🛠 ` | Character to be shown before Xcode version |
+| `SPACESHIP_XCODE_SYMBOL` | `🛠·` | Character to be shown before Xcode version |
 | `SPACESHIP_XCODE_COLOR` | `blue` | Color of Xcode section |
 
 ### Swift (`swift`)
@@ -340,7 +340,7 @@ Haskell section is shown only in directories that contain `stack.yaml` file.
 | `SPACESHIP_HASKELL_SHOW` | `true` | Shown current Haskell Tool Stack version or not |
 | `SPACESHIP_HASKELL_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the Haskell section |
 | `SPACESHIP_HASKELL_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the Haskell section |
-| `SPACESHIP_HASKELL_SYMBOL` | `λ ` | Character to be shown before Haskell Tool Stack version |
+| `SPACESHIP_HASKELL_SYMBOL` | `λ·` | Character to be shown before Haskell Tool Stack version |
 | `SPACESHIP_HASKELL_COLOR` | `red` | Color of Haskell section |
 
 ### Julia (`julia`)
@@ -397,7 +397,7 @@ Show activated conda virtual environment. Disable native conda prompt by `conda 
 | `SPACESHIP_CONDA_SHOW` | `true` | Show current Python conda virtualenv or not |
 | `SPACESHIP_CONDA_PREFIX` | `$SPACESHIP_PROMPT_DEFAULT_PREFIX` | Prefix before the conda virtualenv section |
 | `SPACESHIP_CONDA_SUFFIX` | `$SPACESHIP_PROMPT_DEFAULT_SUFFIX` | Suffix after the conda virtualenv section |
-| `SPACESHIP_CONDA_SYMBOL` | `🅒 ` | Character to be shown before conda virtualenv section |
+| `SPACESHIP_CONDA_SYMBOL` | `🅒·` | Character to be shown before conda virtualenv section |
 | `SPACESHIP_CONDA_COLOR` | `blue` | Color of conda virtualenv environment section |
 
 ### Pyenv (`pyenv`)


### PR DESCRIPTION
Fixes https://github.com/denysdovhan/spaceship-zsh-theme/pull/313#discussion_r162015222

Hope I didn't miss anything.